### PR TITLE
feat(networks): add Sepolia testnet as hidden route

### DIFF
--- a/src/components/ChainMenu.tsx
+++ b/src/components/ChainMenu.tsx
@@ -9,6 +9,7 @@ import { Link, Typography, useMediaQuery } from "@mui/material";
 import { Link as LinkRouter, Location, useLocation } from "react-router-dom";
 import gnosis from "../assets/logos/gnosis.png";
 import ethereum from "../assets/logos/ethereum.png";
+import sepolia from "../assets/logos/ethereum.png";
 import { useTheme } from "@mui/system";
 
 function changeChainIdFromLocation(
@@ -45,6 +46,9 @@ export default function ChainMenu({ chainId }: { chainId: string }) {
       <img src={gnosis} alt="gnosis network" height={"20px"} />
     </>
   );
+  const sepolia_logo = (
+    <img src={sepolia} alt="sepolia testnet" height={"20px"} />
+  );
 
   return (
     <Fragment>
@@ -70,12 +74,21 @@ export default function ChainMenu({ chainId }: { chainId: string }) {
                   </Typography>
                 ) : null}
               </>
+            ) : chainId === "11155111" ? (
+              <>
+                {sepolia_logo}
+                {!mobile ? (
+                  <Typography color={theme.palette.primary.light}>
+                    Sepolia Testnet
+                  </Typography>
+                ) : null}
+              </>
             ) : (
               <>
                 {gnosis_logo}
                 {!mobile ? (
                   <Typography color={theme.palette.primary.light}>
-                    Gnosis (xDAI    )
+                    Gnosis (xDAI)
                   </Typography>
                 ) : null}
               </>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -100,7 +100,7 @@ export default function Layout() {
 
   const theme = useTheme();
   const location = useLocation();
-  const match = location.pathname.match('(100|1)(?:/|$)')
+  const match = location.pathname.match('(11155111|100|1)(?:/|$)')
   const chainId = match ? match[1] : '1'
 
   const toggleDrawer = () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,6 +32,39 @@ import Community from "./pages/Community";
 import RedirectDispute from "./pages/RedirectDispute";
 import AggregatedCharts from "./pages/AggregatedCharts";
 
+function buildChainRoutes(chainId: string) {
+  return [
+    { path: `/${chainId}/`, element: <Home />},
+    { path: `/${chainId}/odds`, element: <Odds />},
+    { path: `/${chainId}/community`, element: <Community />},
+    { path: `/${chainId}/support`, element: <Support /> },
+    { path: `/${chainId}/stakes`, element: <Stakes /> },
+    { path: `/${chainId}/calculator`, element: <Calculator /> },
+    { path: `/${chainId}/solutions`, element: <Solutions /> },
+    { path: `/${chainId}/charts`, element: <Charts /> },
+    { path: `/${chainId}/courts`, children: [
+        { index: true, element: <Courts /> },
+        { path: ':id', element: <Court /> }
+      ]
+    },
+    { path: `/${chainId}/cases`, children: [
+        { index: true, element: <Disputes /> },
+        { path: ':id', element: <Dispute /> }
+      ]
+    },
+    { path: `/${chainId}/arbitrables`, children: [
+        { index: true, element: <Arbitrables /> },
+        { path: ':id', element: <Arbitrable /> }
+      ]
+    },
+    { path: `/${chainId}/profile`, children: [
+        { index: true, element: <Profile /> },
+        { path: ':id', element: <Profile /> }
+      ]
+    },
+  ];
+}
+
 function App() {
   const validChainIds = ['1', '100'];
   const routes = [
@@ -39,47 +72,15 @@ function App() {
       path: '/',
       element: <Layout />,
       children: [
-        ...validChainIds.flatMap((chainId: string) => {
-          return [
-            { index: true, element: <Navigate to='/1' replace />},
-            {
-              path: "/aggregated-charts", element: <AggregatedCharts />
-            },
-            { path: `/${chainId}/`, element: <Home />},
-            { path: `/${chainId}/odds`, element: <Odds />},
-            { path: `/${chainId}/community`, element: <Community />},
-            { path: `/${chainId}/support`, element: <Support /> },
-            { path: `/${chainId}/stakes`, element: <Stakes /> },
-            { path: `/${chainId}/calculator`, element: <Calculator /> },
-            { path: `/${chainId}/solutions`, element: <Solutions /> },
-            { path: `/${chainId}/charts`, element: <Charts /> },
-            { path: `/${chainId}/courts`, children: [
-                { index: true, element: <Courts /> },
-                { path: ':id', element: <Court /> }
-              ]
-            },
-            {path: `/${chainId}/cases`, children: [
-                { index: true, element: <Disputes /> },
-                { path: ':id', element: <Dispute /> }
-              ]
-            },
-            {path: `/${chainId}/arbitrables`, children: [
-                { index: true, element: <Arbitrables /> },
-                { path: ':id', element: <Arbitrable /> }
-              ]
-            },
-            {path: `/${chainId}/profile`, children: [
-                { index: true, element: <Profile /> },
-                { path: ':id', element: <Profile /> }
-              ]
-            },
-            {
-              path: "*",
-              element: <div>Not Found</div>,
-            },
-          ]
-        }
-        )
+        { index: true, element: <Navigate to='/1' replace />},
+        { path: "/aggregated-charts", element: <AggregatedCharts /> },
+        ...validChainIds.flatMap(buildChainRoutes),
+        // Sepolia: ruta no publicada, solo para uso interno/testnet
+        ...buildChainRoutes('11155111'),
+        {
+          path: "*",
+          element: <div>Not Found</div>,
+        },
       ]
     },
     {

--- a/src/lib/apolloClient.ts
+++ b/src/lib/apolloClient.ts
@@ -46,7 +46,7 @@ const curateMainnetClient = new ApolloClient({
 const sepoliaClient = new ApolloClient({
   uri:
     process.env.REACT_APP_SUBGRAPH_SEPOLIA ||
-    'https://api.studio.thegraph.com/query/66145/klerosboard-sepolia/v0.0.1',
+    'https://api.studio.thegraph.com/query/66145/klerosboard-sepolia/version/latest',
   cache: new InMemoryCache(),
   headers: {
     'Content-Type': 'application/json',

--- a/src/lib/apolloClient.ts
+++ b/src/lib/apolloClient.ts
@@ -43,6 +43,17 @@ const curateMainnetClient = new ApolloClient({
   cache: new InMemoryCache(),
 });
 
+const sepoliaClient = new ApolloClient({
+  uri:
+    process.env.REACT_APP_SUBGRAPH_SEPOLIA ||
+    'https://api.studio.thegraph.com/query/66145/klerosboard-sepolia/version/latest',
+  cache: new InMemoryCache(),
+  headers: {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${process.env.REACT_APP_GRAPHQL_TOKEN}`,
+  },
+});
+
 const apolloClientQuery = async <T>(
   chainId: string,
   queryString: string,
@@ -50,6 +61,8 @@ const apolloClientQuery = async <T>(
 ) => {
   if (chainId === '100')
     return apolloQuery<T>(gnosisClient, queryString, variables);
+  if (chainId === '11155111')
+    return apolloQuery<T>(sepoliaClient, queryString, variables);
   return apolloQuery<T>(mainnetClient, queryString, variables);
 };
 

--- a/src/lib/apolloClient.ts
+++ b/src/lib/apolloClient.ts
@@ -46,7 +46,7 @@ const curateMainnetClient = new ApolloClient({
 const sepoliaClient = new ApolloClient({
   uri:
     process.env.REACT_APP_SUBGRAPH_SEPOLIA ||
-    'https://api.studio.thegraph.com/query/66145/klerosboard-sepolia/version/latest',
+    'https://api.studio.thegraph.com/query/66145/klerosboard-sepolia/v0.0.1',
   cache: new InMemoryCache(),
   headers: {
     'Content-Type': 'application/json',

--- a/src/pages/Arbitrable.tsx
+++ b/src/pages/Arbitrable.tsx
@@ -19,7 +19,7 @@ import { useDisputes } from '../hooks/useDisputes';
 export default function Arbitrable() {
   let { id } = useParams();
   const location = useLocation();
-  const match = location.pathname.match('(100|1)(?:/|$)')
+  const match = location.pathname.match('(11155111|100|1)(?:/|$)')
   const chainId = match ? match[1] : null
 
   const { data: arbitrable, isLoading } = useArbitrable(chainId!, id!);

--- a/src/pages/Arbitrables.tsx
+++ b/src/pages/Arbitrables.tsx
@@ -24,7 +24,7 @@ function getArbitrableName(arbitrable: string, arbitrableNames: LItem[] | undefi
 
 export default function Arbitrables() {
   const location = useLocation();
-  const match = location.pathname.match('(100|1)(?:/|$)')
+  const match = location.pathname.match('(11155111|100|1)(?:/|$)')
   const chainId = match ? match[1] : null
   const { data: arbitrables, isLoading } = useArbitrables(chainId!);
   const { data: arbitrablesNames } = useArbitrablesNames();

--- a/src/pages/Charts.tsx
+++ b/src/pages/Charts.tsx
@@ -97,7 +97,7 @@ function clusterByKey(
 
 export default function Charts() {
   const location = useLocation();
-  const match = location.pathname.match("(100|1)(?:/|$)");
+  const match = location.pathname.match("(11155111|100|1)(?:/|$)");
   const chainId = match ? match[1] : null;
   const [dataByCourts, setDataByCourts] = useState<
     { key: string; value: number; percentage: number }[] | undefined

--- a/src/pages/Court.tsx
+++ b/src/pages/Court.tsx
@@ -15,7 +15,7 @@ import LatestStakes from '../components/LatestStakes'
 export default function Court() {
   let { id } = useParams();
   const location = useLocation();
-  const match = location.pathname.match('(100|1)(?:/|$)')
+  const match = location.pathname.match('(11155111|100|1)(?:/|$)')
   const chainId = match ? match[1] : null
   const { data: court } = useCourt(chainId!, id!)
   const courtName = useCourtName(chainId!, id!)

--- a/src/pages/Courts.tsx
+++ b/src/pages/Courts.tsx
@@ -12,7 +12,7 @@ import { CustomFooter } from "../components/DataGridFooter";
 
 export default function Courts() {
   const location = useLocation();
-  const match = location.pathname.match("(100|1)(?:/|$)");
+  const match = location.pathname.match("(11155111|100|1)(?:/|$)");
   const chainId = match ? match[1] : null;
   const { data, isLoading } = useCourts({ chainId: chainId! });
 

--- a/src/pages/Dispute.tsx
+++ b/src/pages/Dispute.tsx
@@ -15,7 +15,7 @@ import EvidenceCard from "../components/EvidenceCard";
 export default function Dispute() {
   let { id } = useParams();
   const location = useLocation();
-  const match = location.pathname.match('(100|1)(?:/|$)')
+  const match = location.pathname.match('(11155111|100|1)(?:/|$)')
   const chainId = match ? match[1] : null
 
   const { data } = useDispute(chainId!, id!);

--- a/src/pages/Disputes.tsx
+++ b/src/pages/Disputes.tsx
@@ -13,7 +13,7 @@ import GAVEL from "../assets/icons/gavel_violet.png";
 
 export default function Disputes() {
   const location = useLocation();
-  const match = location.pathname.match("(100|1)(?:/|$)");
+  const match = location.pathname.match("(11155111|100|1)(?:/|$)");
   const chainId = match ? match[1] : null;
   const { data: disputes, isLoading } = useDisputes({ chainId: chainId! });
   const [pageSize, setPageSize] = useState<number>(10);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -94,7 +94,7 @@ export function getPercentageStaked(
 
 export default function Home() {
   const location = useLocation();
-  const match = location.pathname.match("(100|1)(?:/|$)");
+  const match = location.pathname.match("(11155111|100|1)(?:/|$)");
   const chainId = match ? match[1] : null;
 
   const [relativeDate] = useState<Date>(new Date()); // To avoid refetching the query

--- a/src/pages/Odds.tsx
+++ b/src/pages/Odds.tsx
@@ -40,7 +40,7 @@ const formStyle = {
 
 export default function Odds() {
   const location = useLocation();
-  const match = location.pathname.match('(100|1)(?:/|$)')
+  const match = location.pathname.match('(11155111|100|1)(?:/|$)')
   const chainId = match ? match[1] : null
   const [court, setCourt] = useState<string | undefined>(undefined);
   const [generalCourtOdds, setGeneralCourtOdds] = useState<string | undefined>(undefined);

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -17,7 +17,7 @@ import LatestStakes from '../components/LatestStakes';
 export default function Profile() {
   let { id } = useParams();
   const location = useLocation();
-  const match = location.pathname.match('(100|1)(?:/|$)')
+  const match = location.pathname.match('(11155111|100|1)(?:/|$)')
   const chainId = match ? match[1] : null
 
   const blockExplorer = getBlockExplorer(chainId!);

--- a/src/pages/Stakes.tsx
+++ b/src/pages/Stakes.tsx
@@ -16,7 +16,7 @@ import STAKES from '../assets/icons/icosahedron_violet.png';
 
 export default function Stakes() {
   const location = useLocation();
-  const match = location.pathname.match('(100|1)(?:/|$)')
+  const match = location.pathname.match('(11155111|100|1)(?:/|$)')
   const chainId = match ? match[1] : null
 
   const { data: stakes, isLoading } = useStakes({chainId:chainId!});


### PR DESCRIPTION
## Summary

- Adds Sepolia testnet (chainId `11155111`) support as an unlisted/hidden route
- Routes are accessible via `/11155111/*` but not exposed in the navigation menu or chain switcher options
- Refactors route definition into a reusable `buildChainRoutes(chainId)` helper

## Changes

| File | Change |
|------|--------|
| `src/lib/apolloClient.ts` | Added `sepoliaClient` + `REACT_APP_SUBGRAPH_SEPOLIA` env var; added `11155111` case to `apolloClientQuery` |
| `src/index.tsx` | Extracted `buildChainRoutes()` helper; Sepolia routes registered outside `validChainIds` flatMap |
| `src/components/Layout.tsx` | Updated regex `(11155111\|100\|1)` — order matters to avoid greedy match on `1` |
| `src/components/ChainMenu.tsx` | Added "Sepolia Testnet" label when active, but NOT listed as a selectable option |

## Access

Navigate directly to any of these URLs:
- `/11155111/`
- `/11155111/cases`
- `/11155111/courts`
- `/11155111/profile/:address`