### PR TITLE
fix(ui): MUI v9 aesthetic fixes, grid layout, DataGrid API, and dynamic script sandbox

### DIFF
--- a/src/components/Arbitrable/ArbitrableInfo.tsx
+++ b/src/components/Arbitrable/ArbitrableInfo.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 const dollarFormat = {
-    style: "currency",
+    style: "currency" as const,
     currency: "USD",
     maximumFractionDigits: 2,
 }

--- a/src/components/Case/CaseInfo.tsx
+++ b/src/components/Case/CaseInfo.tsx
@@ -160,7 +160,7 @@ export default function CaseInfo(props: Props) {
             </Grid>
           </Grid>
 
-          <Grid container size={{ xs: 12, md: 12 }}
+          <Grid container size={{ xs: 12, md: 6 }}
             sx={{ justifyContent: "start", alignContent: "center" }}
           >
              <Grid sx={{ margin: "10px" }}>
@@ -190,20 +190,20 @@ export default function CaseInfo(props: Props) {
 
       <Divider sx={{ margin: "10px 0px", width: "90%", marginLeft: "5%" }} />
       <Grid container spacing={2}>
-         <Grid size={12} sx={{ display: "inline-flex" }}>
-          <img src={BALANCE} height="24px" alt="court logo" />{" "}
+         <Grid size={12} sx={{ display: "inline-flex", gap: 1, alignItems: "center" }}>
+          <img src={BALANCE} height="24px" alt="court logo" />
           <Typography>Court: </Typography>
           <Typography>
-            <CourtLink chainId={props.chainId} courtId={props.courtId} />{" "}
+            <CourtLink chainId={props.chainId} courtId={props.courtId} />
           </Typography>
         </Grid>
-         <Grid sx={{ display: "inline-flex" }}>
-           <img src={BOOKMARK} height="24px" alt="date" />{" "}
+         <Grid size={{ xs: 12 }} sx={{ display: "inline-flex", gap: 1, alignItems: "center" }}>
+           <img src={BOOKMARK} height="24px" alt="date" />
           <Typography>Start Date: </Typography>
           <Typography>{formatDate(props.startTimestamp as number)}</Typography>
         </Grid>
-         <Grid sx={{ display: "inline-flex" }}>
-           <img src={BALANCE} height="24px" alt="round" />{" "}
+         <Grid size={{ xs: 12 }} sx={{ display: "inline-flex", gap: 1, alignItems: "center" }}>
+           <img src={BALANCE} height="24px" alt="round" />
           <Typography>Round: </Typography>
           <Typography>{props.roundNum}</Typography>
         </Grid>

--- a/src/components/Case/RoundPanel.tsx
+++ b/src/components/Case/RoundPanel.tsx
@@ -67,10 +67,10 @@ export default function RoundPanel(props: Props) {
         <div key={`RoundPanel-${props.roundId as string}`}>
             <Grid container width={'100%'} sx={{ marginTop: '20px' }}>
                 <Grid container size={12} columnSpacing={10} sx={{ alignItems: 'center' }}>
-                    <Grid sx={{ display: 'inline-flex', alignItems: 'center' }}>
+                    <Grid size="auto" sx={{ display: 'inline-flex', alignItems: 'center' }}>
                         <img src={USER_VIOLET} height='16px' alt='jurors' style={{ marginRight: '5px' }} /><Typography>{props.votes.length} Jurors</Typography>
                     </Grid>
-                    <Grid sx={{ display: 'inline-flex', alignItems: 'center' }}>
+                    <Grid size="auto" sx={{ display: 'inline-flex', alignItems: 'center' }}>
                         <img src={BALANCE_VIOLET} height='16px' alt='jury' style={{ marginRight: '5px' }} />
                         <Typography>Jury Decision:&nbsp;</Typography><Typography>{juryDecison}</Typography>
                     </Grid>

--- a/src/components/Case/RoundPanel.tsx
+++ b/src/components/Case/RoundPanel.tsx
@@ -65,7 +65,7 @@ export default function RoundPanel(props: Props) {
 
     return (
         <div key={`RoundPanel-${props.roundId as string}`}>
-            <Grid container width={'100%'} sx={{ marginTop: '20px' }}>
+            <Grid container sx={{ marginTop: '20px', width: '100%' }}>
                 <Grid container size={12} columnSpacing={10} sx={{ alignItems: 'center' }}>
                     <Grid size="auto" sx={{ display: 'inline-flex', alignItems: 'center' }}>
                         <img src={USER_VIOLET} height='16px' alt='jurors' style={{ marginRight: '5px' }} /><Typography>{props.votes.length} Jurors</Typography>

--- a/src/components/Case/VotePanel.tsx
+++ b/src/components/Case/VotePanel.tsx
@@ -7,7 +7,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { Vote } from '../../graphql/subgraph';
 import JurorLink from '../JurorLink';
 import { formatDate, voteMapping } from '../../lib/helpers';
-import { Grid, List, ListItem, Tooltip } from '@mui/material';
+import { Box, Grid, List, ListItem, Tooltip } from '@mui/material';
 import { MetaEvidence } from '../../lib/types';
 
 interface Props {
@@ -54,10 +54,10 @@ export default function VotePanel(props: Props) {
         aria-controls="panel1a-content"
         id="panel1a-header"
       >
-        <Grid container sx={{margin:'0px 10px'}}>
+        <Grid container sx={{ margin: '0px 10px', width: '100%' }}>
           <Grid size={{ xs: 12, md: 3 }}>
             <JurorLink address={props.vote.address.id} chainId={props.chainId}/></Grid>
-          <Grid>
+          <Grid size="grow">
           <Tooltip title="If a * is in the text, means the most probably title for the vote when an error raise reading metaEvidence of the dispute."><Typography sx={justificationStyle}> {voteChoice}</Typography></Tooltip>
           </Grid>
         </Grid>
@@ -65,14 +65,19 @@ export default function VotePanel(props: Props) {
       <AccordionDetails>
         <List dense={true}>
           <ListItem key={`vote-${props.vote.id}`}>
-            <Typography>Vote:  </Typography><Typography sx={voteStyle}>{voteChoice} </Typography>
+            <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
+              <Typography>Vote:</Typography>
+              <Typography sx={voteStyle}>{voteChoice}</Typography>
+            </Box>
           </ListItem>
           {/* <ListItem>
             <Typography>Justification:   </Typography><Typography sx={justificationStyle}>Soon...</Typography>
           </ListItem> */}
           <ListItem key={`date-${props.vote.id}`}>
-            <Typography>Date:    </Typography>
-            <Typography sx={voteStyle}>{props.vote.timestamp ? formatDate(props.vote.timestamp as number): null}</Typography>
+            <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
+              <Typography>Date:</Typography>
+              <Typography sx={voteStyle}>{props.vote.timestamp ? formatDate(props.vote.timestamp as number) : null}</Typography>
+            </Box>
           </ListItem>
         </List>
       </AccordionDetails>

--- a/src/components/Case/VotingHistory.tsx
+++ b/src/components/Case/VotingHistory.tsx
@@ -9,7 +9,7 @@ import { MetaEvidence } from '../../lib/types';
 
 interface Props {
     rounds: Round[]
-    disptueId: BigNumberish
+    disputeId: BigNumberish
     chainId: string
     metaEvidence?: MetaEvidence
 }
@@ -75,7 +75,7 @@ export default function VotingHistory(props: Props) {
                 props.rounds.map((round, index) => {
                     return (
                         <TabPanel value={value} index={index} key={`TabPanel-${index}`}>
-                            <RoundPanel disputeId={props.disptueId} votes={round.votes} chainId={props.chainId} roundId={round.id} metaEvidence={props.metaEvidence}/>
+                            <RoundPanel disputeId={props.disputeId} votes={round.votes} chainId={props.chainId} roundId={round.id} metaEvidence={props.metaEvidence}/>
                         </TabPanel>
                     )
                 })

--- a/src/components/ChainMenu.tsx
+++ b/src/components/ChainMenu.tsx
@@ -102,22 +102,24 @@ export default function ChainMenu({ chainId }: { chainId: string }) {
         open={open}
         onClose={handleClose}
         onClick={handleClose}
-        PaperProps={{
-          elevation: 0,
-          sx: {
-            overflow: "visible",
-            mt: 1.5,
-            "&:before": {
-              content: '""',
-              display: "block",
-              position: "absolute",
-              top: 0,
-              right: 14,
-              width: 10,
-              height: 10,
-              bgcolor: "background.paper",
-              transform: "translateY(-50%) rotate(45deg)",
-              zIndex: 0,
+        slotProps={{
+          paper: {
+            elevation: 0,
+            sx: {
+              overflow: "visible",
+              mt: 1.5,
+              "&:before": {
+                content: '""',
+                display: "block",
+                position: "absolute",
+                top: 0,
+                right: 14,
+                width: 10,
+                height: 10,
+                bgcolor: "background.paper",
+                transform: "translateY(-50%) rotate(45deg)",
+                zIndex: 0,
+              },
             },
           },
         }}

--- a/src/components/Court/CourtInfo.tsx
+++ b/src/components/Court/CourtInfo.tsx
@@ -41,7 +41,7 @@ const semiBold = {
 };
 
 const dollarFormat = {
-  style: "currency",
+  style: "currency" as const,
   currency: "USD",
   maximumFractionDigits: 2,
 };

--- a/src/components/DataGridFooter.tsx
+++ b/src/components/DataGridFooter.tsx
@@ -37,7 +37,7 @@ export function CustomFooter() {
 
   return (
     <GridToolbarContainer sx={{ display:'flex',justifyContent: 'flex-start' }}>
-      <Grid sm={4} flex={1}>
+      <Grid size={{ sm: 4 }} sx={{ flex: 1 }}>
         <Button
           {...buttonBaseProps}
           onClick={() => handleExport({ getRowsToExport: getUnfilteredRows })}
@@ -45,7 +45,7 @@ export function CustomFooter() {
           Download CSV
         </Button>
       </Grid>
-      <Grid sm={4}>
+      <Grid size={{ sm: 4 }}>
         <Pagination
           color="primary"
           count={pageCount}
@@ -55,7 +55,7 @@ export function CustomFooter() {
           onChange={(event, value) => apiRef.current.setPage(value - 1)}
         />
       </Grid>
-      <Grid flex={1} sm={4}></Grid>
+      <Grid sx={{ flex: 1 }} size={{ sm: 4 }}></Grid>
     </GridToolbarContainer>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -39,7 +39,7 @@ export default function Header(props: { logo: string, title: string , text: stri
                 }}>{props.title}</Typography>
 
             </Grid>
-            <Grid sm={12}>
+            <Grid size={{ sm: 12 }}>
                 {
                 typeof(props.text) === 'string'
                 ?<Typography variant='body1' style={{

--- a/src/components/LatestDisputes.tsx
+++ b/src/components/LatestDisputes.tsx
@@ -74,8 +74,8 @@ export default function LatestDisputes(props: Props) {
                 disableSelectionOnClick
                 autoHeight={true}
                 hideFooter={props.hideFooter === undefined? true: props.hideFooter}
-                components={{
-                  Footer: CustomFooter
+                 slots={{
+                  footer: CustomFooter
                 }}
             />}
         </Box>

--- a/src/components/LatestDisputes.tsx
+++ b/src/components/LatestDisputes.tsx
@@ -71,7 +71,7 @@ export default function LatestDisputes(props: Props) {
                 columns={props.courtRendering ? dispute_columns_court : dispute_columns}
                 loading={disputes_loading}
                 paginationModel={{ page: 0, pageSize: 10 }}
-                disableSelectionOnClick
+                disableRowSelectionOnClick
                 autoHeight={true}
                 hideFooter={props.hideFooter === undefined? true: props.hideFooter}
                  slots={{

--- a/src/components/LatestDisputes.tsx
+++ b/src/components/LatestDisputes.tsx
@@ -33,7 +33,7 @@ export default function LatestDisputes(props: Props) {
             field: 'currentRulling', headerName: 'Current Ruling', flex: 1
         },
          { field: 'period', headerName: 'Period', flex: 1, valueFormatter: (value: any) => {
-             return (value.charAt(0).toUpperCase() + value.slice(1))
+             return typeof value === 'string' ? value.charAt(0).toUpperCase() + value.slice(1) : (value ?? '')
          }}
      ];
      const dispute_columns_court: GridColDef<Dispute>[] = [
@@ -41,7 +41,7 @@ export default function LatestDisputes(props: Props) {
              <Link component={LinkRouter} to={`/${props.chainId}/cases/${params.value}`} children={params.value} />
          ) },
           { field: 'period', headerName: 'Period', flex: 1, valueFormatter: (value: any) => {
-              return (value.charAt(0).toUpperCase() + value.slice(1))
+              return typeof value === 'string' ? value.charAt(0).toUpperCase() + value.slice(1) : (value ?? '')
           }
           },
          {

--- a/src/components/LatestDisputes.tsx
+++ b/src/components/LatestDisputes.tsx
@@ -1,8 +1,8 @@
 import { Box, Typography } from '@mui/material';
-import { DataGrid, GridRenderCellParams } from '@mui/x-data-grid';
+import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import { BigNumberish } from '../lib/types';
 import React from 'react'
-import { Court } from '../graphql/subgraph';
+import { Court, Dispute } from '../graphql/subgraph';
 import { useDisputes } from '../hooks/useDisputes';
 import { formatDate, getPeriodNumber } from '../lib/helpers';
 import CourtLink from './CourtLink';
@@ -20,37 +20,37 @@ interface Props {
 export default function LatestDisputes(props: Props) {
     const { data: disputes, isLoading: disputes_loading } = useDisputes({chainId: props.chainId, subcourtID: props.courtId});
 
-     const dispute_columns = [
-         { field: 'id', headerName: '#', flex: 1,renderCell: (params: GridRenderCellParams<Court>) => (
+     const dispute_columns: GridColDef<Dispute>[] = [
+         { field: 'id', headerName: '#', flex: 1, renderCell: (params: GridRenderCellParams<Dispute, string>) => (
              <Link component={LinkRouter} to={`/${props.chainId}/cases/${params.value}`} children={params.value} />
          ) },
          {
-             field: 'subcourtID', headerName: 'Court', flex: 2, renderCell: (params: GridRenderCellParams<Court>) => (
+             field: 'subcourtID', headerName: 'Court', flex: 2, renderCell: (params: GridRenderCellParams<Dispute, Court>) => (
                  <CourtLink chainId={props.chainId} courtId={params.value!.id as string} />
              )
          },
         {
             field: 'currentRulling', headerName: 'Current Ruling', flex: 1
         },
-         { field: 'period', headerName: 'Period', flex: 1, valueFormatter: (value) => {
+         { field: 'period', headerName: 'Period', flex: 1, valueFormatter: (value: any) => {
              return (value.charAt(0).toUpperCase() + value.slice(1))
          }}
-    ];
-     const dispute_columns_court = [
-         { field: 'id', headerName: '#', flex: 1,renderCell: (params: GridRenderCellParams<string>) => (
+     ];
+     const dispute_columns_court: GridColDef<Dispute>[] = [
+         { field: 'id', headerName: '#', flex: 1, renderCell: (params: GridRenderCellParams<Dispute, string>) => (
              <Link component={LinkRouter} to={`/${props.chainId}/cases/${params.value}`} children={params.value} />
          ) },
-          { field: 'period', headerName: 'Period', flex: 1, valueFormatter: (value) => {
+          { field: 'period', headerName: 'Period', flex: 1, valueFormatter: (value: any) => {
               return (value.charAt(0).toUpperCase() + value.slice(1))
           }
           },
          {
-             field: 'lastPeriodChange', headerName: 'Last period Change', flex: 2, renderCell: (params: GridRenderCellParams<BigNumberish>) => (
+             field: 'lastPeriodChange', headerName: 'Last period Change', flex: 2, renderCell: (params: GridRenderCellParams<Dispute, BigNumberish>) => (
                  formatDate(Number(params.value!))
              )
          },
          {
-             field: 'subcourtID', headerName: 'Period Ends', flex: 2, renderCell: (params: GridRenderCellParams<Court>) => {
+             field: 'subcourtID', headerName: 'Period Ends', flex: 2, renderCell: (params: GridRenderCellParams<Dispute, Court>) => {
                  if (params.row.period !== 'execution') {
                      return formatDate(Number(params.row.lastPeriodChange) + Number(params.value!.timePeriods[getPeriodNumber(params.row.period)]))
                  }
@@ -65,7 +65,7 @@ export default function LatestDisputes(props: Props) {
         <Box>
 
             <Typography sx={{ fontSize: '24px', fontWeight: 600, fontStyle: 'normal' }}>Latest Cases</Typography>
-            {<DataGrid
+            {<DataGrid<Dispute>
                 sx={{ marginTop: '30px' }}
                 rows={disputes ? disputes! : []}
                 columns={props.courtRendering ? dispute_columns_court : dispute_columns}

--- a/src/components/LatestStakes.tsx
+++ b/src/components/LatestStakes.tsx
@@ -148,8 +148,8 @@ export default function LatestStakes(props: Props) {
           disableSelectionOnClick
           autoHeight={true}
           hideFooter={props.hideFooter === undefined ? true : props.hideFooter}
-          components={{
-            Footer: CustomFooter,
+          slots={{
+            footer: CustomFooter,
           }}
         />
       }

--- a/src/components/LatestStakes.tsx
+++ b/src/components/LatestStakes.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Box, Typography } from "@mui/material";
 import { DataGrid, GridRenderCellParams } from "@mui/x-data-grid";
 import { shortenAddress } from "../lib/utils";
-import { BigNumberish } from "../../lib/types";
+import { BigNumberish } from "../lib/types";
 import { Juror } from "../graphql/subgraph";
 import { useStakes } from "../hooks/useStakes";
 import CourtLink from "./CourtLink";
@@ -145,7 +145,7 @@ export default function LatestStakes(props: Props) {
           }
           loading={stakes_loading}
           paginationModel={{ page: 0, pageSize: 10 }}
-          disableSelectionOnClick
+          disableRowSelectionOnClick
           autoHeight={true}
           hideFooter={props.hideFooter === undefined ? true : props.hideFooter}
           slots={{

--- a/src/components/LatestStakes.tsx
+++ b/src/components/LatestStakes.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { Box, Typography } from "@mui/material";
-import { DataGrid, GridRenderCellParams } from "@mui/x-data-grid";
+import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import { shortenAddress } from "../lib/utils";
-import { BigNumberish } from "../lib/types";
-import { Juror } from "../graphql/subgraph";
+import { StakeSet } from "../graphql/subgraph";
 import { useStakes } from "../hooks/useStakes";
 import CourtLink from "./CourtLink";
 import { Link as LinkRouter } from "react-router-dom";
@@ -24,13 +23,13 @@ export default function LatestStakes(props: Props) {
     subcourtID: props.courtId,
     jurorID: props.jurorId,
   });
-  const columns_stakes = [
+  const columns_stakes: GridColDef<StakeSet>[] = [
      {
        field: "address",
        headerName: "Juror",
        flex: 1,
        valueFormatter: (value: any) => `${(value as any).id}`,
-       renderCell: (params: GridRenderCellParams<Juror>) => (
+       renderCell: (params: GridRenderCellParams<StakeSet, { id: string }>) => (
          <Link
            component={LinkRouter}
            to={`/${props.chainId}/profile/${params.value!.id}`}
@@ -42,8 +41,8 @@ export default function LatestStakes(props: Props) {
        field: "subcourtID",
        headerName: "Court Name",
        flex: 2,
-       renderCell: (params: GridRenderCellParams<BigNumberish>) => (
-         <CourtLink chainId={props.chainId} courtId={params.value! as string} />
+       renderCell: (params: GridRenderCellParams<StakeSet>) => (
+         <CourtLink chainId={props.chainId} courtId={params.value as string} />
        ),
      },
     {
@@ -56,13 +55,13 @@ export default function LatestStakes(props: Props) {
       },
     },
   ];
-  const columns_stakes_wihtout_court = [
+  const columns_stakes_wihtout_court: GridColDef<StakeSet>[] = [
      {
        field: "address",
        headerName: "Juror",
        flex: 1,
        valueFormatter: (value: any) => `${(value as any).id}`,
-       renderCell: (params: GridRenderCellParams<Juror>) => (
+       renderCell: (params: GridRenderCellParams<StakeSet, { id: string }>) => (
          <Link
            component={LinkRouter}
            to={`/${props.chainId}/profile/${params.value!.id}`}
@@ -88,13 +87,13 @@ export default function LatestStakes(props: Props) {
     },
   ];
 
-  const columns_stakes_for_juror = [
+  const columns_stakes_for_juror: GridColDef<StakeSet>[] = [
      {
        field: "subcourtID",
        headerName: "Court Name",
        flex: 2,
-       renderCell: (params: GridRenderCellParams<BigNumberish>) => (
-         <CourtLink chainId={props.chainId} courtId={params.value! as string} />
+       renderCell: (params: GridRenderCellParams<StakeSet>) => (
+         <CourtLink chainId={props.chainId} courtId={params.value as string} />
        ),
        valueFormatter: (value: any) => { return `${value}`
        }
@@ -133,7 +132,7 @@ export default function LatestStakes(props: Props) {
         Latest Stakes
       </Typography>
       {
-        <DataGrid
+        <DataGrid<StakeSet>
           sx={{ marginTop: "30px" }}
           rows={stakes ? stakes! : []}
           columns={

--- a/src/components/PeriodStatus.tsx
+++ b/src/components/PeriodStatus.tsx
@@ -7,7 +7,7 @@ import Typography from '@mui/material/Typography';
 import { Court } from '../graphql/subgraph';
 import { intervalToDuration } from 'date-fns'
 import { formatDuration } from 'date-fns'
-import { BigNumberish } from '../../lib/types';
+import { BigNumberish } from '../lib/types';
 import { getPeriodNumber, getTimeLeft } from '../lib/helpers';
 import { useI18nContext } from '../lib/I18nContext';
 import { useMediaQuery, useTheme } from '@mui/material';

--- a/src/components/Profile/CreatedCases.tsx
+++ b/src/components/Profile/CreatedCases.tsx
@@ -1,5 +1,5 @@
 import { Box, Skeleton, Typography } from "@mui/material";
-import { DataGrid, GridRenderCellParams } from "@mui/x-data-grid";
+import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import { BigNumberish } from "../../lib/types";
 import React from "react";
 import { formatDate, getBlockExplorer } from "../../lib/helpers";
@@ -18,12 +18,12 @@ interface Props {
 export default function CreatedCases(props: Props) {
   const blockExplorer = getBlockExplorer(props.chainId);
 
-  const dispute_columns = [
+  const dispute_columns: GridColDef<Dispute>[] = [
     {
       field: "id",
       headerName: "#",
       flex: 1,
-      renderCell: (params: GridRenderCellParams) => (
+      renderCell: (params: GridRenderCellParams<Dispute>) => (
         <Link
           component={LinkRouter}
           to={`/${props.chainId}/cases/${params.row.id}`}
@@ -35,7 +35,7 @@ export default function CreatedCases(props: Props) {
       field: "subcourtID",
       headerName: "Court",
       flex: 2,
-      renderCell: (params: GridRenderCellParams<Court>) => (
+      renderCell: (params: GridRenderCellParams<Dispute, Court>) => (
         <CourtLink
           chainId={props.chainId}
           courtId={params.value?.id as string}
@@ -46,14 +46,14 @@ export default function CreatedCases(props: Props) {
       field: "startTime",
       headerName: "Date",
       flex: 2,
-      renderCell: (params: GridRenderCellParams<BigNumberish>) =>
+      renderCell: (params: GridRenderCellParams<Dispute, BigNumberish>) =>
         formatDate(Number(params.value)),
     },
     {
       field: "txid",
       headerName: "txID",
       flex: 1,
-      renderCell: (params: GridRenderCellParams<string>) => (
+      renderCell: (params: GridRenderCellParams<Dispute, string>) => (
         <a
           href={`${blockExplorer}/tx/${params.value}`}
           rel="noreferrer"
@@ -77,7 +77,7 @@ export default function CreatedCases(props: Props) {
         {props.cases ? props.cases.length : <Skeleton width={"20px"} />}{" "}
       </Typography>
       {
-        <DataGrid
+        <DataGrid<Dispute>
           sx={{ marginTop: "30px" }}
           rows={props.cases ? props.cases! : []}
           columns={dispute_columns}

--- a/src/components/Profile/CreatedCases.tsx
+++ b/src/components/Profile/CreatedCases.tsx
@@ -83,7 +83,7 @@ export default function CreatedCases(props: Props) {
           columns={dispute_columns}
           loading={props.isLoading}
           paginationModel={{ page: 0, pageSize: 10 }}
-          disableSelectionOnClick
+          disableRowSelectionOnClick
           autoHeight={true}
           hideFooter={false}
           slots={{

--- a/src/components/Profile/ProfileStats.tsx
+++ b/src/components/Profile/ProfileStats.tsx
@@ -10,7 +10,7 @@ import { useTokenInfo } from '../../hooks/useTokenInfo';
 import { formatEther } from 'viem';
 
 const dollarFormat = {
-    style: "currency",
+    style: "currency" as const,
     currency: "USD",
     maximumFractionDigits: 2,
 }

--- a/src/components/Profile/ProfileStats.tsx
+++ b/src/components/Profile/ProfileStats.tsx
@@ -43,7 +43,7 @@ export default function ProfileStats(props: Props) {
             padding: '10px'
         }}>
             <Grid container sx={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
-                <Grid container size={{ xs: 12, md: 5 }} sx={{ flexDirection: 'row' }} minHeight={'230px'}>
+                <Grid container size={{ xs: 12, md: 5 }} sx={{ flexDirection: 'row', minHeight: '230px' }}>
                     <Grid container size={6} sx={{ flexDirection: 'column', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                         <Grid>
                             <Typography>Juror in {props.profile.numberOfDisputesAsJuror} Cases</Typography>

--- a/src/components/Profile/VotedCases.tsx
+++ b/src/components/Profile/VotedCases.tsx
@@ -115,7 +115,7 @@ export default function VotedCases(props: Props) {
            loading={props.isLoading}
            onPaginationModelChange={(model) => setPageSize(model.pageSize)}
            pageSizeOptions={[10, 50, 100]}
-           disableSelectionOnClick
+            disableRowSelectionOnClick
            autoHeight={true}
            initialState={{
              sorting: {

--- a/src/components/Profile/VotedCases.tsx
+++ b/src/components/Profile/VotedCases.tsx
@@ -1,5 +1,5 @@
 import { Box, Link, Skeleton, Typography } from "@mui/material";
-import { DataGrid, GridRenderCellParams } from "@mui/x-data-grid";
+import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import { BigNumberish } from "../../lib/types";
 import React, { useState } from "react";
 import { Link as LinkRouter } from "react-router-dom";
@@ -16,14 +16,14 @@ interface Props {
 
 export default function VotedCases(props: Props) {
   const [pageSize, setPageSize] = useState<number>(10);
-  const columns = [
+  const columns: GridColDef<Vote>[] = [
     {
       field: "dispute",
       headerName: "#",
       flex: 1,
       valueFormatter: (value: Dispute) => `${value?.id ?? ""}`,
       sortComparator: (a: Dispute, b: Dispute) => Number(a.id) - Number(b.id),
-      renderCell: (params: GridRenderCellParams<Dispute>) => (
+      renderCell: (params: GridRenderCellParams<Vote, Dispute>) => (
         <Link
           component={LinkRouter}
           to={`/${props.chainId}/cases/${params.value?.id}`}
@@ -35,7 +35,7 @@ export default function VotedCases(props: Props) {
       field: "subcourtID",
       headerName: "Court",
       flex: 1,
-      renderCell: (params: GridRenderCellParams) => (
+      renderCell: (params: GridRenderCellParams<Vote>) => (
         <CourtLink
           chainId={props.chainId}
           courtId={params.row.dispute.subcourtID.id as string}
@@ -47,14 +47,14 @@ export default function VotedCases(props: Props) {
       headerName: "Round",
       flex: 2,
       valueFormatter: (value: Round) => `${value?.id?.split("-").at(-1) ?? ""}`,
-      renderCell: (params: GridRenderCellParams<Round>) =>
+      renderCell: (params: GridRenderCellParams<Vote, Round>) =>
         params.value?.id?.split("-").at(-1),
     },
     {
       field: "period",
       headerName: "Period",
       flex: 1,
-      renderCell: (params: GridRenderCellParams) => {
+      renderCell: (params: GridRenderCellParams<Vote>) => {
         const period = params.row.dispute?.period ?? "";
         return period.charAt(0).toUpperCase() + period.slice(1);
       },
@@ -63,7 +63,7 @@ export default function VotedCases(props: Props) {
       field: "choice",
       headerName: "Vote",
       flex: 1,
-      renderCell: (params: GridRenderCellParams<BigNumberish>) => {
+      renderCell: (params: GridRenderCellParams<Vote, BigNumberish>) => {
         if (params.row) {
           return (
             <VoteMapping
@@ -79,7 +79,7 @@ export default function VotedCases(props: Props) {
       field: "currentRulling",
       headerName: "Current Rulling",
       flex: 1,
-      renderCell: (params: GridRenderCellParams<BigNumberish>) => {
+      renderCell: (params: GridRenderCellParams<Vote, BigNumberish>) => {
         if (params.row) {
           return (
             <VoteMapping
@@ -107,7 +107,7 @@ export default function VotedCases(props: Props) {
         {props.votes ? props.votes.length : <Skeleton width={"20px"} />}{" "}
       </Typography>
        {
-         <DataGrid
+         <DataGrid<Vote>
            sx={{ marginTop: "30px" }}
            rows={props.votes ? props.votes! : []}
            columns={columns}

--- a/src/components/RowLinks.tsx
+++ b/src/components/RowLinks.tsx
@@ -20,21 +20,23 @@ export default function RowLinks() {
     <div>
       <Grid container
          sx={{
+           width: '100%',
            justifyContent: 'space-between',
-           display: 'inline-flex',
            alignItems: 'center',
            border: '1px solid #E5E5E5',
            boxShadow: '0px 2px 3px rgba(0, 0, 0, 0.06)',
-           borderRadius: '3px'
+           borderRadius: '3px',
+           marginBottom: '8px',
          }}>
         <div style={{
           width: '5px',
           height: '64px',
-          background: '#9013FE'
+          background: '#9013FE',
+          borderRadius: '3px 0 0 3px',
         }}>
         </div>
-        <Grid size={{ xs: 11, sm: 7 }} sx={{ display: 'inline-flex' }}><Typography>Kleros</Typography><Typography>Links</Typography></Grid>
-        <Grid size={{ xs: 11, sm: 4 }} sx={{ display: 'inherit', justifyContent: 'end', marginRight: '30px' }}>
+        <Grid size="grow" sx={{ display: 'inline-flex', paddingLeft: '16px' }}><Typography>Kleros</Typography><Typography>Links</Typography></Grid>
+        <Grid size="auto" sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', marginRight: '30px' }}>
           <a href='https://kleros.io' target="_blank" rel="noreferrer"><img src={WEB} style={img} alt='Web' /></a>
           <a href='https://github.com/kleros' target="_blank" rel="noreferrer"><img src={GITHUB} style={img} alt='Github' /></a>
           <a href='https://snapshot.org/#/kleros.eth/' target="_blank" rel="noreferrer"><img src={SNAPSHOT} style={img} alt='Snapshot' /></a>
@@ -48,21 +50,22 @@ export default function RowLinks() {
 
     <Grid container
         sx={{
+          width: '100%',
           justifyContent: 'space-between',
-          display: 'inline-flex',
           alignItems: 'center',
           border: '1px solid #E5E5E5',
           boxShadow: '0px 2px 3px rgba(0, 0, 0, 0.06)',
-          borderRadius: '3px'
+          borderRadius: '3px',
         }}>
         <div style={{
           width: '5px',
           height: '64px',
-          background: '#FF9900'
+          background: '#FF9900',
+          borderRadius: '3px 0 0 3px',
         }}>
         </div>
-        <Grid size={{ xs: 11, sm: 7 }} sx={{ display: 'inline-flex' }}><Typography>Proof of Humanity</Typography><Typography>Links</Typography></Grid>
-        <Grid size={{ xs: 11, sm: 4 }} sx={{ display: 'inherit', justifyContent: 'end', marginRight: '30px' }}>
+        <Grid size="grow" sx={{ display: 'inline-flex', paddingLeft: '16px' }}><Typography>Proof of Humanity</Typography><Typography>Links</Typography></Grid>
+        <Grid size="auto" sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', marginRight: '30px' }}>
           <a href='https://proofofhumanity.id' target="_blank" rel="noreferrer"><img src={WEB} style={img} alt='Web' /></a>
           <a href='https://github.com/proof-Of-Humanity/' target="_blank" rel="noreferrer"><img src={GITHUB} style={img} alt='Github' /></a>
           <a href='https://snapshot.org/#/kleros.eth/' target="_blank" rel="noreferrer"><img src={SNAPSHOT} style={img} alt='Snapshot' /></a>

--- a/src/components/RowLinks.tsx
+++ b/src/components/RowLinks.tsx
@@ -56,6 +56,7 @@ export default function RowLinks() {
           border: '1px solid #E5E5E5',
           boxShadow: '0px 2px 3px rgba(0, 0, 0, 0.06)',
           borderRadius: '3px',
+          marginBottom: '8px',
         }}>
         <div style={{
           width: '5px',

--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -2,7 +2,7 @@ import { CardMedia, Grid, Skeleton } from "@mui/material";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
-import { BigNumberish } from "../../lib/types";
+import { BigNumberish } from "../lib/types";
 import * as React from "react";
 
 const valueCSS = {

--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -68,7 +68,7 @@ export default function StatCard({
            />
          </Grid>
 
-         <Grid size={9} padding="0px">
+         <Grid size={9} sx={{ padding: "0px" }}>
            <CardContent>
              <Typography sx={titleCSS} gutterBottom noWrap>
                {title}

--- a/src/hooks/useArbitrable.ts
+++ b/src/hooks/useArbitrable.ts
@@ -17,7 +17,7 @@ export const useArbitrable = (chainId: string = '1', arbitrableId?:string) => {
     queryFn: async () => {
       const response = await apolloClientQuery<{ arbitrable: Arbitrable }>(chainId, query, {arbitrableId});
       if (!response) throw new Error("No response from TheGraph");
-      return response.data.arbitrable;
+      return response.data!.arbitrable;
     },
     enabled: !!chainId && !!arbitrableId,
   });

--- a/src/hooks/useArbitrable.ts
+++ b/src/hooks/useArbitrable.ts
@@ -16,7 +16,7 @@ export const useArbitrable = (chainId: string = '1', arbitrableId?:string) => {
     queryKey: ["useArbitrable", chainId, arbitrableId],
     queryFn: async () => {
       const response = await apolloClientQuery<{ arbitrable: Arbitrable }>(chainId, query, {arbitrableId});
-      if (!response) throw new Error("No response from TheGraph");
+      if (!response || !response.data) throw new Error("No response from TheGraph");
       return response.data!.arbitrable;
     },
     enabled: !!chainId && !!arbitrableId,

--- a/src/hooks/useArbitrableName.ts
+++ b/src/hooks/useArbitrableName.ts
@@ -34,7 +34,7 @@ export const useArbitrableName = (arbitrableId: string) => {
       litems: LItem[];
     }>(buildQuery(query, variables), variables);
 
-    if (!response) throw new Error("No response from TheGraph");
+    if (!response || !response.data) throw new Error("No response from TheGraph");
     if (response.data!.litems.length !== 0) {
       name = response.data!.litems[0].keywords.split(" | ")[1];
     } else {

--- a/src/hooks/useArbitrableName.ts
+++ b/src/hooks/useArbitrableName.ts
@@ -35,8 +35,8 @@ export const useArbitrableName = (arbitrableId: string) => {
     }>(buildQuery(query, variables), variables);
 
     if (!response) throw new Error("No response from TheGraph");
-    if (response.data.litems.length !== 0) {
-      name = response.data.litems[0].keywords.split(" | ")[1];
+    if (response.data!.litems.length !== 0) {
+      name = response.data!.litems[0].keywords.split(" | ")[1];
     } else {
       // search in mainnet list
       variables["registryAddress"] = ADDRESS_TAG_REGISTRY_MAINNET;
@@ -47,8 +47,8 @@ export const useArbitrableName = (arbitrableId: string) => {
 
       if (!response2) throw new Error("No response from TheGraph");
 
-      if (response2.data.litems.length !== 0) {
-        name = response2.data.litems[0].keywords.split(" | ")[1];
+      if (response2.data!.litems.length !== 0) {
+        name = response2.data!.litems[0].keywords.split(" | ")[1];
       }
     }
     return name;

--- a/src/hooks/useArbitrables.ts
+++ b/src/hooks/useArbitrables.ts
@@ -17,7 +17,7 @@ export const useArbitrables = (chainId: string = '1') => {
     queryKey: ["useArbitrables", chainId],
     queryFn: async () => {
       const response = await apolloClientQuery<{ arbitrables: [Arbitrable] }>(chainId, query);
-      if (!response) throw new Error("No response from TheGraph");
+      if (!response || !response.data) throw new Error("No response from TheGraph");
       return response.data!.arbitrables;
     },
     enabled: !!chainId,

--- a/src/hooks/useArbitrables.ts
+++ b/src/hooks/useArbitrables.ts
@@ -18,7 +18,7 @@ export const useArbitrables = (chainId: string = '1') => {
     queryFn: async () => {
       const response = await apolloClientQuery<{ arbitrables: [Arbitrable] }>(chainId, query);
       if (!response) throw new Error("No response from TheGraph");
-      return response.data.arbitrables;
+      return response.data!.arbitrables;
     },
     enabled: !!chainId,
   });

--- a/src/hooks/useArbitrablesNames.ts
+++ b/src/hooks/useArbitrablesNames.ts
@@ -30,8 +30,8 @@ export const useArbitrablesNames = () => {
         }>(buildQuery(query, variables), variables);
 
         if (!response) throw new Error("No response from TheGraph");
-        litems = litems.concat(response.data.litems);
-        iterate = response.data.litems.length === 1000;
+        litems = litems.concat(response.data!.litems);
+        iterate = response.data!.litems.length === 1000;
       }
       const skipOffset = litems.length;
       iterate = true;
@@ -45,8 +45,8 @@ export const useArbitrablesNames = () => {
         }>(buildQuery(query, variables), variables);
 
         if (!response2) throw new Error("No response from TheGraph");
-        litems = litems.concat(response2.data.litems);
-        iterate = response2.data.litems.length === 1000;
+        litems = litems.concat(response2.data!.litems);
+        iterate = response2.data!.litems.length === 1000;
       }
       return litems;
     }

--- a/src/hooks/useArbitrablesNames.ts
+++ b/src/hooks/useArbitrablesNames.ts
@@ -29,7 +29,7 @@ export const useArbitrablesNames = () => {
           litems: LItem[];
         }>(buildQuery(query, variables), variables);
 
-        if (!response) throw new Error("No response from TheGraph");
+        if (!response || !response.data) throw new Error("No response from TheGraph");
         litems = litems.concat(response.data!.litems);
         iterate = response.data!.litems.length === 1000;
       }

--- a/src/hooks/useCourt.ts
+++ b/src/hooks/useCourt.ts
@@ -19,7 +19,7 @@ export const useCourt = (chainId: string = '1', courtId:string) => {
 
       if (!response) throw new Error("No response from TheGraph");
 
-      return response.data.court;
+      return response.data!.court;
     },
     enabled: !!chainId,
   });

--- a/src/hooks/useCourt.ts
+++ b/src/hooks/useCourt.ts
@@ -17,7 +17,7 @@ export const useCourt = (chainId: string = '1', courtId:string) => {
     queryFn: async () => {
       const response = await apolloClientQuery<{ court: Court }>(chainId, query, {id:courtId});
 
-      if (!response) throw new Error("No response from TheGraph");
+      if (!response || !response.data) throw new Error("No response from TheGraph");
 
       return response.data!.court;
     },

--- a/src/hooks/useCourts.ts
+++ b/src/hooks/useCourts.ts
@@ -29,7 +29,7 @@ export const useCourts = ({chainId, subcourtID}: Props) => {
 
       const response = await apolloClientQuery<{ courts: Court[] }>(chainId, buildQuery(query, variables), variables);
 
-      if (!response) throw new Error("No response from TheGraph");
+      if (!response || !response.data) throw new Error("No response from TheGraph");
 
       return response.data!.courts;
     },

--- a/src/hooks/useCourts.ts
+++ b/src/hooks/useCourts.ts
@@ -31,7 +31,7 @@ export const useCourts = ({chainId, subcourtID}: Props) => {
 
       if (!response) throw new Error("No response from TheGraph");
 
-      return response.data.courts;
+      return response.data!.courts;
     },
   });
 };

--- a/src/hooks/useDispute.ts
+++ b/src/hooks/useDispute.ts
@@ -17,7 +17,7 @@ export const useDispute = (chainId: string = '1', disputeId:string) => {
     queryFn: async () => {
       const response = await apolloClientQuery<{ dispute: Dispute }>(chainId, query, {disputeId:disputeId});
 
-      if (!response) throw new Error("No response from TheGraph");
+      if (!response || !response.data) throw new Error("No response from TheGraph");
 
       return response.data!.dispute;
     },

--- a/src/hooks/useDispute.ts
+++ b/src/hooks/useDispute.ts
@@ -19,7 +19,7 @@ export const useDispute = (chainId: string = '1', disputeId:string) => {
 
       if (!response) throw new Error("No response from TheGraph");
 
-      return response.data.dispute;
+      return response.data!.dispute;
     },
     enabled: !!chainId,
   });

--- a/src/hooks/useDisputes.ts
+++ b/src/hooks/useDisputes.ts
@@ -38,7 +38,7 @@ export const useDisputes = ({chainId, subcourtID, arbitrableID, creator}: Props)
         
         let response = await apolloClientQuery<{ disputes: Dispute[] }>(chainId, buildQuery(query, variables), variables);
 
-        if (!response) throw new Error("No response from TheGraph");
+        if (!response || !response.data) throw new Error("No response from TheGraph");
         
         disputes = response.data!.disputes;
 
@@ -47,7 +47,7 @@ export const useDisputes = ({chainId, subcourtID, arbitrableID, creator}: Props)
         
           response = await apolloClientQuery<{ disputes: Dispute[] }>(chainId, buildQuery(query, variables), variables);
 
-          if (!response) throw new Error("No response from TheGraph");
+          if (!response || !response.data) throw new Error("No response from TheGraph");
           disputes = disputes.concat(response.data!.disputes);
         }
 

--- a/src/hooks/useDisputes.ts
+++ b/src/hooks/useDisputes.ts
@@ -21,7 +21,7 @@ interface Props {
 
 export const useDisputes = ({chainId, subcourtID, arbitrableID, creator}: Props) => {
   return useQuery<Dispute[], Error>({
-    queryKey: ["useDisputes", chainId, subcourtID, arbitrableID],
+    queryKey: ["useDisputes", chainId, subcourtID, arbitrableID, creator],
     queryFn: async () => {
         let disputes: Dispute[] = []
         const variables: QueryVariables = {};

--- a/src/hooks/useDisputes.ts
+++ b/src/hooks/useDisputes.ts
@@ -40,15 +40,15 @@ export const useDisputes = ({chainId, subcourtID, arbitrableID, creator}: Props)
 
         if (!response) throw new Error("No response from TheGraph");
         
-        disputes = response.data.disputes;
+        disputes = response.data!.disputes;
 
-        while (response.data.disputes.length === 1000) {
+        while (response.data!.disputes.length === 1000) {
           variables['skip'] = disputes.length;
         
           response = await apolloClientQuery<{ disputes: Dispute[] }>(chainId, buildQuery(query, variables), variables);
 
           if (!response) throw new Error("No response from TheGraph");
-          disputes = disputes.concat(response.data.disputes);
+          disputes = disputes.concat(response.data!.disputes);
         }
 
         return disputes;  

--- a/src/hooks/useJurors.ts
+++ b/src/hooks/useJurors.ts
@@ -19,7 +19,7 @@ export const useJurors = (chainId: string = '1') => {
 
       if (!response) throw new Error("No response from TheGraph");
 
-      return response.data.jurors;
+      return response.data!.jurors;
     },
     enabled: !!chainId
   });

--- a/src/hooks/useJurors.ts
+++ b/src/hooks/useJurors.ts
@@ -17,7 +17,7 @@ export const useJurors = (chainId: string = '1') => {
     queryFn: async () => {
       const response = await apolloClientQuery<{ jurors: Juror[] }>(chainId, query)
 
-      if (!response) throw new Error("No response from TheGraph");
+      if (!response || !response.data) throw new Error("No response from TheGraph");
 
       return response.data!.jurors;
     },

--- a/src/hooks/useKlerosCounters.ts
+++ b/src/hooks/useKlerosCounters.ts
@@ -40,10 +40,10 @@ export const useKlerosCounter = ({ chainId, relTimestamp }: Props) => {
       } else {
         response = await apolloClientQuery<{ klerosCounter: KlerosCounter }>(chainId, query);
       }
-      if (!response) throw new Error("No response from TheGraph");
-      if (!response.data) throw new Error("No data from TheGraph");
+      if (!response || !response.data) throw new Error("No response from TheGraph");
+      if (!response.data.klerosCounter) throw new Error("KlerosCounter entity not found");
 
-      return response.data.klerosCounter as KlerosCounter;
+      return response.data.klerosCounter;
     }
   });
 };

--- a/src/hooks/useKlerosCounters.ts
+++ b/src/hooks/useKlerosCounters.ts
@@ -2,7 +2,6 @@ import { KLEROSCOUNTERS_FIELDS, KlerosCounter } from "../graphql/subgraph";
 import { useQuery } from "@tanstack/react-query";
 import { apolloClientQuery } from "../lib/apolloClient";
 import { getBlockByDate } from "../lib/helpers";
-import { ApolloQueryResult } from "@apollo/client";
 
 const query = `
     ${KLEROSCOUNTERS_FIELDS}
@@ -30,9 +29,9 @@ interface Props {
 export const useKlerosCounter = ({ chainId, relTimestamp }: Props) => {
   return useQuery<KlerosCounter, Error>({
     queryKey: ["useklerosCounter", chainId, relTimestamp],
-    queryFn: async () => {
+    queryFn: async (): Promise<KlerosCounter> => {
 
-      let response: ApolloQueryResult<{ klerosCounter: KlerosCounter }> | undefined
+      let response: Awaited<ReturnType<typeof apolloClientQuery<{ klerosCounter: KlerosCounter }>>>
       if (relTimestamp) {
         const blockNumber = (await getBlockByDate(relTimestamp, chainId)).block;
 
@@ -42,8 +41,9 @@ export const useKlerosCounter = ({ chainId, relTimestamp }: Props) => {
         response = await apolloClientQuery<{ klerosCounter: KlerosCounter }>(chainId, query);
       }
       if (!response) throw new Error("No response from TheGraph");
+      if (!response.data) throw new Error("No data from TheGraph");
 
-      return response.data.klerosCounter;
+      return response.data.klerosCounter as KlerosCounter;
     }
   });
 };

--- a/src/hooks/useMostActiveCourt.ts
+++ b/src/hooks/useMostActiveCourt.ts
@@ -43,7 +43,7 @@ export const useMostActiveCourt = ({ chainId, relTimestamp }: Props) => {
     queryKey: ["useMostActiveCourt", chainId, relTimestamp],
     queryFn: async () => {
       let response = await apolloClientQuery<{ courts: Court[] }>(chainId, query);
-      if (!response) throw new Error("No response from TheGraph");
+      if (!response || !response.data) throw new Error("No response from TheGraph");
 
       if (relTimestamp) {
         const blockNumber = (await getBlockByDate(relTimestamp, chainId)).block;

--- a/src/hooks/useMostActiveCourt.ts
+++ b/src/hooks/useMostActiveCourt.ts
@@ -53,9 +53,9 @@ export const useMostActiveCourt = ({ chainId, relTimestamp }: Props) => {
         let responseRel = await apolloClientQuery<{ courts: Court[] }>(chainId, relQuery, { blockNumber: blockNumber });
 
         if (!responseRel) throw new Error("No response from TheGraph");
-        return getCourtMaxDiff(responseRel.data.courts, response.data.courts)
+        return getCourtMaxDiff(responseRel.data!.courts, response.data!.courts)
       }
-      return response.data.courts.reduce((a, b) => Number(a.disputesNum) > Number(b.disputesNum) ? a : b);
+      return (response.data!.courts as Court[]).reduce((a: Court, b: Court) => Number(a.disputesNum) > Number(b.disputesNum) ? a : b);
     }
   });
 };

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -19,7 +19,7 @@ export const useProfile = (chainId: string = '1', profileID:string) => {
 
       if (!response) throw new Error("No response from TheGraph");
 
-      return response.data.juror;
+      return response.data!.juror;
     },
     enabled: !!chainId
   });

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -17,7 +17,7 @@ export const useProfile = (chainId: string = '1', profileID:string) => {
     queryFn: async () => {
       const response = await apolloClientQuery<{ juror: Juror }>(chainId, query, {jurorID: profileID.toLowerCase()});
 
-      if (!response) throw new Error("No response from TheGraph");
+      if (!response || !response.data) throw new Error("No response from TheGraph");
 
       return response.data!.juror;
     },

--- a/src/hooks/useRelativeCourtData.ts
+++ b/src/hooks/useRelativeCourtData.ts
@@ -55,7 +55,7 @@ export const useRelativeCourtData = ({
 
       if (!responseRel) throw new Error("No response from TheGraph");
 
-      return Number(response.data.court.disputesNum) - Number(responseRel.data.court.disputesNum);
+      return Number(response.data!.court.disputesNum) - Number(responseRel.data!.court.disputesNum);
     }
   });
 };

--- a/src/hooks/useRelativeCourtData.ts
+++ b/src/hooks/useRelativeCourtData.ts
@@ -41,7 +41,7 @@ export const useRelativeCourtData = ({
         query,
         { courtId: courtId }
       );
-      if (!response) throw new Error("No response from TheGraph");
+      if (!response || !response.data) throw new Error("No response from TheGraph");
 
       const blockNumber = Number(await getBlockByDate(relTimestamp, chainId));
 

--- a/src/hooks/useStakes.ts
+++ b/src/hooks/useStakes.ts
@@ -36,7 +36,7 @@ export const useStakes = ({chainId, subcourtID, jurorID}: Props)  => {
 
       if (!response) throw new Error("No response from TheGraph");
 
-      return response.data.stakeSets;
+      return response.data!.stakeSets;
     },
     enabled: !!chainId
   });

--- a/src/hooks/useStakes.ts
+++ b/src/hooks/useStakes.ts
@@ -34,7 +34,7 @@ export const useStakes = ({chainId, subcourtID, jurorID}: Props)  => {
 
       const response = await apolloClientQuery<{ stakeSets: StakeSet[] }>(chainId, buildQuery(query, variables), variables);
 
-      if (!response) throw new Error("No response from TheGraph");
+      if (!response || !response.data) throw new Error("No response from TheGraph");
 
       return response.data!.stakeSets;
     },

--- a/src/hooks/useVotes.ts
+++ b/src/hooks/useVotes.ts
@@ -32,7 +32,7 @@ export const useVotes = ({chainId, subcourtID, jurorID}: Props) => {
 
       const response = await apolloClientQuery<{ votes: Vote[] }>(chainId, buildQuery(query, variables), variables);
 
-      if (!response) throw new Error("No response from TheGraph");
+      if (!response || !response.data) throw new Error("No response from TheGraph");
 
       return response.data!.votes;
     },

--- a/src/hooks/useVotes.ts
+++ b/src/hooks/useVotes.ts
@@ -34,7 +34,7 @@ export const useVotes = ({chainId, subcourtID, jurorID}: Props) => {
 
       if (!response) throw new Error("No response from TheGraph");
 
-      return response.data.votes;
+      return response.data!.votes;
     },
     enabled: !!chainId,
   });

--- a/src/lib/apolloClient.ts
+++ b/src/lib/apolloClient.ts
@@ -3,7 +3,6 @@ import {
   gql,
   HttpLink,
   InMemoryCache,
-  NormalizedCacheObject,
 } from '@apollo/client';
 
 const authHeaders = {
@@ -81,7 +80,7 @@ const apolloCurateMainnetQuery = async <T>(
 };
 
 const apolloQuery = async <T>(
-  client: ApolloClient<NormalizedCacheObject>,
+  client: ApolloClient,
   queryString: string,
   variables: Record<string, any> = {},
 ) => {

--- a/src/lib/dynamicScriptSandbox.ts
+++ b/src/lib/dynamicScriptSandbox.ts
@@ -50,7 +50,13 @@ export default function executeDynamicScript(
       }
     };
 
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     const cleanup = () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
       window.removeEventListener("message", messageHandler);
       if (blobUrl) {
         URL.revokeObjectURL(blobUrl);
@@ -62,6 +68,11 @@ export default function executeDynamicScript(
 
     window.addEventListener("message", messageHandler);
     document.body.appendChild(iframe);
+
+    timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error("Dynamic script sandbox timeout after 30s"));
+    }, 30000);
 
     // Build the iframe content as an HTML document
     // Structure:
@@ -124,8 +135,8 @@ ${scriptString}
 // The function may return a value directly OR a Promise (governor scripts are async).
 try {
   const result = getMetaEvidence();
-  if (result && typeof result.then === 'function') {
-    result.then(resolveScript).catch(function(err) {
+    if (result && typeof result.then === 'function') {
+    Promise.resolve(result).then(resolveScript).catch(function(err) {
       rejectScript(new Error('getMetaEvidence() async error: ' + (err && err.message ? err.message : String(err))));
     });
   } else {

--- a/src/lib/dynamicScriptSandbox.ts
+++ b/src/lib/dynamicScriptSandbox.ts
@@ -120,10 +120,17 @@ ${scriptString}
 </script>
 
 <script>
-// Call getMetaEvidence() after the user script has defined it
+// Call getMetaEvidence() after the user script has defined it.
+// The function may return a value directly OR a Promise (governor scripts are async).
 try {
   const result = getMetaEvidence();
-  resolveScript(result);
+  if (result && typeof result.then === 'function') {
+    result.then(resolveScript).catch(function(err) {
+      rejectScript(new Error('getMetaEvidence() async error: ' + (err && err.message ? err.message : String(err))));
+    });
+  } else {
+    resolveScript(result);
+  }
 } catch (error) {
   rejectScript(new Error('getMetaEvidence() threw: ' + (error instanceof Error ? error.message : String(error))));
 }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,5 +1,5 @@
 import { BigNumberish } from "./types";
-import { intervalToDuration, compareAsc, format, formatDuration, fromUnixTime } from "date-fns";
+import { Duration, intervalToDuration, compareAsc, format, formatDuration, fromUnixTime } from "date-fns";
 import { enGB, es } from "date-fns/locale";
 import { DecimalBigNumber } from "./DecimalBigNumber";
 
@@ -89,7 +89,7 @@ export function getTimeLeft(
 
   const duration = intervalToDuration({ start: startDate, end: endDate });
 
-  const format = ["years", "months", "weeks", "days", "hours"];
+  const format: (keyof Duration)[] = ["years", "months", "weeks", "days", "hours"];
 
   if (withSeconds) {
     format.push("minutes", "seconds");
@@ -168,9 +168,9 @@ export const getCourtName = async (chainid: string, id: string) => {
 
   if (!response) throw new Error("No response from TheGraph");
 
-  if (response.data.court === null || response.data.court.policy === null)
+  if (response.data!.court === null || response.data!.court.policy === null)
     return "Unknown";
-  const url = "https://cdn.kleros.link" + response.data.court.policy.policy;
+  const url = "https://cdn.kleros.link" + response.data!.court.policy.policy;
   const r = await fetch(url);
   const courtName = await r.json();
   return courtName.name;

--- a/src/pages/AggregatedCharts.tsx
+++ b/src/pages/AggregatedCharts.tsx
@@ -101,7 +101,7 @@ export default function AggregatedCharts() {
         title='Charts'
         text="Aggregated KPIs for Kleros Court in all it's chains"
       />
-       <Grid container sx={{ justifyContent: 'center', alignItems: 'start' }}>
+       <Grid container sx={{ justifyContent: 'center', alignItems: 'start', width: '100%' }}>
          <Grid container columnSpacing={0} sx={row_css}>
            <Grid size={{ xs: 12, md: 4, lg: 2 }}><StatCard title={'PNK Staked'} subtitle={`%${totalSupply && kc ? getPercentageStaked(kc, totalSupply) : '...'} Staked`} value={kc ? formatPNK(kc.tokenStaked) : undefined} image={KLEROS} /></Grid>
            <Grid size={{ xs: 12, md: 4, lg: 2 }}><StatCard title={`Fees Paid`} subtitle={'All times'} value={kc_eth && kc_gno ? `${formatAmount(kc_eth.totalETHFees, '1')}ETH + ${formatAmount(kc_gno.totalETHFees, '100')}DAI` : undefined} image={ETHEREUM} /></Grid>

--- a/src/pages/Arbitrable.tsx
+++ b/src/pages/Arbitrable.tsx
@@ -96,7 +96,7 @@ export default function Arbitrable() {
              loading={isLoadingDisputes}
              onPaginationModelChange={(model) => setPageSize(model.pageSize)}
              pageSizeOptions={[10, 50, 100]}
-             disableSelectionOnClick
+             disableRowSelectionOnClick
              autoHeight={true}
              sx={{
                backgroundColor: '#FFFFFF',

--- a/src/pages/Arbitrable.tsx
+++ b/src/pages/Arbitrable.tsx
@@ -63,7 +63,7 @@ export default function Arbitrable() {
   return (
     <div>
       <Header
-        title={`Arbitrable:${arbitrableName? arbitrableName! : 'Loading...'}`}
+        title={`Arbitrable: ${arbitrableName ?? id}`}
         logo={ARBITRABLE}
         text={
           <div style={{ alignItems: 'center', display: 'flex' }}>

--- a/src/pages/Arbitrable.tsx
+++ b/src/pages/Arbitrable.tsx
@@ -8,12 +8,11 @@ import ARBITRABLE from '../assets/icons/arbitrable_violet.png'
 import ARROW_RIGHT from '../assets/icons/arrow_right_blue.png'
 import ArbitrableInfo from '../components/Arbitrable/ArbitrableInfo';
 import { Skeleton, Typography } from '@mui/material';
-import { DataGrid, GridRenderCellParams } from '@mui/x-data-grid';
+import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import { Link } from '@mui/material';
-import { BigNumberish } from '../lib/types';
 import CourtLink from '../components/CourtLink';
 import { CustomFooter } from '../components/DataGridFooter';
-import { Court } from '../graphql/subgraph';
+import { Court, Dispute } from '../graphql/subgraph';
 import { useDisputes } from '../hooks/useDisputes';
 
 export default function Arbitrable() {
@@ -28,14 +27,14 @@ export default function Arbitrable() {
   const blockExplorer = getBlockExplorer(chainId!);
   const [pageSize, setPageSize] = useState<number>(10);
 
-   const columns = [
+   const columns: GridColDef<Dispute>[] = [
      {
-       field: 'id', headerName: 'Case #', flex: 1, renderCell: (params: GridRenderCellParams<string>) => (
+       field: 'id', headerName: 'Case #', flex: 1, renderCell: (params: GridRenderCellParams<Dispute, string>) => (
          <Link component={LinkRouter} to={`/${chainId}/cases/${params.value!}`} children={`#${params.value!}`} />
        )
      },
      {
-       field: 'subcourtID', headerName: 'Court Name', flex: 2, renderCell: (params: GridRenderCellParams<Court>) => (
+       field: 'subcourtID', headerName: 'Court Name', flex: 2, renderCell: (params: GridRenderCellParams<Dispute, Court>) => (
          <CourtLink chainId={chainId!} courtId={params.value!.id as string} />
        )
      },
@@ -43,17 +42,17 @@ export default function Arbitrable() {
       field: 'currentRulling', headerName: 'Current Ruling', flex: 1
     },
      {
-       field: 'period', headerName: 'Period', flex: 1, valueFormatter: (value) => {
+       field: 'period', headerName: 'Period', flex: 1, valueFormatter: (value: any) => {
          return (value.charAt(0).toUpperCase() + value.slice(1))
        }
      },
      {
-       field: 'lastPeriodChange', headerName: 'Last Period Change', flex: 1, valueFormatter: (value) => {
+       field: 'lastPeriodChange', headerName: 'Last Period Change', flex: 1, valueFormatter: (value: any) => {
          return formatDate(value as number);
        }
      },
      {
-       field: 'txid', headerName: 'txID', flex: 1, renderCell: (params: GridRenderCellParams<string>) => (
+       field: 'txid', headerName: 'txID', flex: 1, renderCell: (params: GridRenderCellParams<Dispute, string>) => (
          <a href={`${blockExplorer}/tx/${params.value}`} rel='noreferrer' target='_blank'>{`${params.value?.slice(0, 6)}...${params.value?.slice(-4)}`}</a>
        )
      }
@@ -89,7 +88,7 @@ export default function Arbitrable() {
              color: '#333333',
              marginTop: '30px'
            }}>Cases Created</Typography>
-           <DataGrid
+           <DataGrid<Dispute>
              rows={disputes ? disputes! : []}
              columns={columns}
              paginationModel={{ page: 0, pageSize }}

--- a/src/pages/Arbitrables.tsx
+++ b/src/pages/Arbitrables.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { formatAmount, getCurrency } from "../lib/helpers";
 import { DataGrid, GridRenderCellParams } from "@mui/x-data-grid";
 import { CustomFooter } from "../components/DataGridFooter";
-import { Link } from "@mui/material";
+import { Link, Skeleton, Typography } from "@mui/material";
 import { Link as LinkRouter, useLocation } from "react-router-dom";
 import { BigNumberish } from "../lib/types";
 import Header from "../components/Header";
@@ -13,12 +13,9 @@ import { LItem } from "../graphql/subgraph";
 import { shortenIfAddress } from "../lib/utils";
 
 
-function getArbitrableName(arbitrable: string, arbitrableNames: LItem[] | undefined): string {
-  if (arbitrableNames) {
-    const foundItem = arbitrableNames.find((item) => item.keywords.split(' | ')[2].toLowerCase() === arbitrable.toLowerCase());
-    return foundItem ? foundItem.keywords.split(' | ')[1] : shortenIfAddress(arbitrable);
-  }
-  return 'Loading...'
+function getArbitrableName(arbitrable: string, arbitrableNames: LItem[]): string {
+  const foundItem = arbitrableNames.find((item) => item.keywords.split(' | ')[2].toLowerCase() === arbitrable.toLowerCase());
+  return foundItem ? foundItem.keywords.split(' | ')[1] : shortenIfAddress(arbitrable);
 }
 
 
@@ -42,14 +39,16 @@ export default function Arbitrables() {
          />
        ),
      },
-     {
-       field: "name",
-       headerName: "Name",
-       flex: 2,
-       renderCell: (params: GridRenderCellParams) => {
-         return getArbitrableName(params.row.id as string, arbitrablesNames);
-       },
-     },
+      {
+        field: "name",
+        headerName: "Name",
+        flex: 2,
+        renderCell: (params: GridRenderCellParams) => {
+          if (!arbitrablesNames) return <Skeleton width={120} />;
+          const name = getArbitrableName(params.row.id as string, arbitrablesNames);
+          return <Typography variant="body2">{name}</Typography>;
+        },
+      },
     {
       field: "disputesCount",
       headerName: "Created Cases",
@@ -83,7 +82,7 @@ export default function Arbitrables() {
            loading={isLoading}
            onPaginationModelChange={(model) => setPageSize(model.pageSize)}
            pageSizeOptions={[10, 50, 100]}
-           disableSelectionOnClick
+            disableRowSelectionOnClick
            autoHeight={true}
            slots={{
              footer: CustomFooter,

--- a/src/pages/Arbitrables.tsx
+++ b/src/pages/Arbitrables.tsx
@@ -1,15 +1,14 @@
 import React, { useState } from "react";
 import { formatAmount, getCurrency } from "../lib/helpers";
-import { DataGrid, GridRenderCellParams } from "@mui/x-data-grid";
+import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import { CustomFooter } from "../components/DataGridFooter";
 import { Link, Skeleton, Typography } from "@mui/material";
 import { Link as LinkRouter, useLocation } from "react-router-dom";
-import { BigNumberish } from "../lib/types";
 import Header from "../components/Header";
 import { useArbitrables } from "../hooks/useArbitrables";
 import ARBITRABLE from "../assets/icons/arbitrable_violet.png";
 import { useArbitrablesNames } from "../hooks/useArbitrablesNames";
-import { LItem } from "../graphql/subgraph";
+import { Arbitrable, LItem } from "../graphql/subgraph";
 import { shortenIfAddress } from "../lib/utils";
 
 
@@ -26,12 +25,12 @@ export default function Arbitrables() {
   const { data: arbitrables, isLoading } = useArbitrables(chainId!);
   const { data: arbitrablesNames } = useArbitrablesNames();
   const [pageSize, setPageSize] = useState<number>(10);
-  const columns = [
+  const columns: GridColDef<Arbitrable>[] = [
      {
        field: "id",
        headerName: "Address",
        flex: 2,
-       renderCell: (params: GridRenderCellParams<{ value: string }>) => (
+       renderCell: (params: GridRenderCellParams<Arbitrable, string>) => (
          <Link
            component={LinkRouter}
            to={`/${chainId}/arbitrables/${params.value}`}
@@ -43,7 +42,7 @@ export default function Arbitrables() {
         field: "name",
         headerName: "Name",
         flex: 2,
-        renderCell: (params: GridRenderCellParams) => {
+        renderCell: (params: GridRenderCellParams<Arbitrable>) => {
           if (!arbitrablesNames) return <Skeleton width={120} />;
           const name = getArbitrableName(params.row.id as string, arbitrablesNames);
           return <Typography variant="body2">{name}</Typography>;
@@ -60,7 +59,7 @@ export default function Arbitrables() {
        headerName: `Fees Generated [${getCurrency(chainId!)}]`,
        flex: 1,
        type: "number",
-       valueFormatter: (value) => {
+       valueFormatter: (value: any) => {
          return formatAmount(value, chainId!);
        },
      },
@@ -75,7 +74,7 @@ export default function Arbitrables() {
       />
 
       {
-         <DataGrid
+         <DataGrid<Arbitrable>
            rows={arbitrables ? arbitrables! : []}
            columns={columns}
            paginationModel={{ page: 0, pageSize }}

--- a/src/pages/Arbitrables.tsx
+++ b/src/pages/Arbitrables.tsx
@@ -46,8 +46,8 @@ export default function Arbitrables() {
        field: "name",
        headerName: "Name",
        flex: 2,
-       valueGetter: (_value: unknown, row: { id: string }) => {
-         return getArbitrableName(row.id, arbitrablesNames);
+       renderCell: (params: GridRenderCellParams) => {
+         return getArbitrableName(params.row.id as string, arbitrablesNames);
        },
      },
     {

--- a/src/pages/Arbitrables.tsx
+++ b/src/pages/Arbitrables.tsx
@@ -13,7 +13,7 @@ import { shortenIfAddress } from "../lib/utils";
 
 
 function getArbitrableName(arbitrable: string, arbitrableNames: LItem[]): string {
-  const foundItem = arbitrableNames.find((item) => item.keywords.split(' | ')[2].toLowerCase() === arbitrable.toLowerCase());
+  const foundItem = arbitrableNames.find((item) => item.keywords.split(' | ')[2]?.toLowerCase() === arbitrable.toLowerCase());
   return foundItem ? foundItem.keywords.split(' | ')[1] : shortenIfAddress(arbitrable);
 }
 
@@ -42,6 +42,10 @@ export default function Arbitrables() {
         field: "name",
         headerName: "Name",
         flex: 2,
+        valueGetter: (_value: unknown, row: Arbitrable) => {
+          if (!arbitrablesNames) return '';
+          return getArbitrableName(row.id, arbitrablesNames);
+        },
         renderCell: (params: GridRenderCellParams<Arbitrable>) => {
           if (!arbitrablesNames) return <Skeleton width={120} />;
           const name = getArbitrableName(params.row.id as string, arbitrablesNames);

--- a/src/pages/Court.tsx
+++ b/src/pages/Court.tsx
@@ -40,7 +40,7 @@ export default function Court() {
         text="Breadcumbs"
       />
 
-      <Grid container spacing={4} sx={{ alignItems: 'center' }}>
+      <Grid container spacing={4} sx={{ alignItems: 'center', width: '100%' }}>
          <Grid size="auto" sx={{ display: 'inline-flex', alignItems: 'baseline' }}>
            <img src={ARROWUP} alt='arrow' height='16px' /><Typography>Court coherency:&nbsp;</Typography><Typography>{court ? `${court.coherency} %` : <Skeleton variant='circular' />}</Typography>
          </Grid>
@@ -58,7 +58,7 @@ export default function Court() {
           : <Skeleton height='200px' />
       }
 
-       <Grid container spacing={2} style={{ marginTop: '40px' }}>
+       <Grid container spacing={2} sx={{ marginTop: '40px' }}>
 
          <Grid size={{ xs: 12, md: 6 }}>
            <LatestStakes chainId={chainId!} courtId={id} hideFooter={false} />

--- a/src/pages/Court.tsx
+++ b/src/pages/Court.tsx
@@ -41,13 +41,13 @@ export default function Court() {
       />
 
       <Grid container spacing={4} sx={{ alignItems: 'center' }}>
-         <Grid sx={{ display: 'inline-flex', alignItems: 'baseline' }}>
+         <Grid size="auto" sx={{ display: 'inline-flex', alignItems: 'baseline' }}>
            <img src={ARROWUP} alt='arrow' height='16px' /><Typography>Court coherency:&nbsp;</Typography><Typography>{court ? `${court.coherency} %` : <Skeleton variant='circular' />}</Typography>
          </Grid>
-         <Grid sx={{ display: 'inline-flex', alignItems: 'baseline' }}>
+         <Grid size="auto" sx={{ display: 'inline-flex', alignItems: 'baseline' }}>
            <img src={ARROWDOWN} alt='arrow' height='16px' /><Typography>Appealed cases:&nbsp;</Typography><Typography>{court ? `${court.appealPercentage} %` : <Skeleton variant='circular' />}</Typography>
          </Grid>
-         <Grid sx={{ display: 'inline-flex', alignItems: 'baseline', marginLeft: 'auto' }}>
+         <Grid size="auto" sx={{ display: 'inline-flex', alignItems: 'baseline', marginLeft: 'auto' }}>
          <Link onClick={exportData} to={'#'}>Download JSON file</Link>
          </Grid>
        </Grid>

--- a/src/pages/Courts.tsx
+++ b/src/pages/Courts.tsx
@@ -120,7 +120,7 @@ export default function Courts() {
            initialState={{
              sorting: { sortModel: [{ field: "id", sort: "asc" }] },
            }}
-           disableSelectionOnClick
+            disableRowSelectionOnClick
            autoHeight={true}
            slots={{
              footer: CustomFooter,

--- a/src/pages/Courts.tsx
+++ b/src/pages/Courts.tsx
@@ -1,15 +1,15 @@
 import React, { useState } from "react";
 import Header from "../components/Header";
 import { useCourts } from "../hooks/useCourts";
-import { DataGrid, GridRenderCellParams } from "@mui/x-data-grid";
+import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 
 import { useLocation } from "react-router-dom";
 import { formatAmount, formatPNK } from "../lib/helpers";
-import { BigNumberish } from "../lib/types";
 import { formatUnits } from "viem";
 import CourtLink from "../components/CourtLink";
 import BALANCE from "../assets/icons/balance_violet.png";
 import { CustomFooter } from "../components/DataGridFooter";
+import { Court } from "../graphql/subgraph";
 
 export default function Courts() {
   const location = useLocation();
@@ -19,14 +19,14 @@ export default function Courts() {
 
   const [pageSize, setPageSize] = useState<number>(10);
 
-  const columns = [
+  const columns: GridColDef<Court>[] = [
     { field: "id", headerName: "Court Id", flex: 1, type: "number" },
      {
        field: "subcourtID",
        headerName: "Court Name",
        flex: 2,
-       renderCell: (params: GridRenderCellParams<BigNumberish>) => (
-         <CourtLink chainId={chainId!} courtId={params.value! as string} />
+       renderCell: (params: GridRenderCellParams<Court>) => (
+         <CourtLink chainId={chainId!} courtId={params.value as string} />
        ),
      },
      {
@@ -34,7 +34,7 @@ export default function Courts() {
        headerName: "Total Staked",
        type: "number",
        flex: 1,
-       valueFormatter: (value) => {
+       valueFormatter: (value: any) => {
          return formatPNK(value, true, true);
        },
      },
@@ -43,7 +43,7 @@ export default function Courts() {
        headerName: "Active Jurors",
        type: "number",
        flex: 1,
-       valueFormatter: (value) => {
+       valueFormatter: (value: any) => {
          return Number(value);
        },
      },
@@ -52,7 +52,7 @@ export default function Courts() {
        headerName: "Fee for Jurors",
        type: "number",
        flex: 1,
-       valueFormatter: (value) => {
+       valueFormatter: (value: any) => {
          return formatAmount(value, chainId!);
        },
      },
@@ -61,7 +61,7 @@ export default function Courts() {
        headerName: "Min Stake",
        type: "number",
        flex: 1,
-       valueFormatter: (value) => {
+       valueFormatter: (value: any) => {
          return formatPNK(value);
        },
      },
@@ -69,9 +69,7 @@ export default function Courts() {
       field: "voteStake",
       headerName: "Vote Stake",
       flex: 1,
-       renderCell: (params: {
-         row: { minStake: BigNumberish; alpha: BigNumberish };
-       }) => {
+       renderCell: (params: GridRenderCellParams<Court>) => {
          return (
            (
              (Number(formatUnits(BigInt(String(params.row.minStake)), 18)) *
@@ -86,7 +84,7 @@ export default function Courts() {
        headerName: "Total Disputes",
        type: "number",
        flex: 1,
-       valueFormatter: (value) => {
+       valueFormatter: (value: any) => {
          return Number(value);
        },
      },
@@ -95,7 +93,7 @@ export default function Courts() {
        headerName: "Open Disputes",
        type: "number",
        flex: 1,
-       valueFormatter: (value) => {
+       valueFormatter: (value: any) => {
          return Number(value);
        },
      },
@@ -110,7 +108,7 @@ export default function Courts() {
       />
 
        {
-         <DataGrid
+         <DataGrid<Court>
            rows={data ? data! : []}
            columns={columns}
            paginationModel={{ page: 0, pageSize }}

--- a/src/pages/Dispute.tsx
+++ b/src/pages/Dispute.tsx
@@ -50,19 +50,15 @@ export default function Dispute() {
       {data !== undefined ? (
         <Grid container>
           <Grid
-            item
-            display={"flex-inline"}
-            marginLeft={"auto"}
-            sm={12}
-            textAlign={"right"}
+            size={12}
+            sx={{ display: "inline-flex", marginLeft: "auto", textAlign: "right" }}
           >
             <Link onClick={exportData} to={"#"}>
               Download JSON file
             </Link>
           </Grid>
           <Grid
-            item
-            sm={12}
+            size={12}
             sx={{
               background: "#FFFFFF",
               padding: "10px",

--- a/src/pages/Dispute.tsx
+++ b/src/pages/Dispute.tsx
@@ -48,10 +48,10 @@ export default function Dispute() {
       />
       {/* Case period */}
       {data !== undefined ? (
-        <Grid container>
+        <Grid container sx={{ width: '100%' }}>
           <Grid
             size={12}
-            sx={{ display: "inline-flex", marginLeft: "auto", textAlign: "right" }}
+            sx={{ display: "flex", justifyContent: "flex-end" }}
           >
             <Link onClick={exportData} to={"#"}>
               Download JSON file
@@ -100,7 +100,7 @@ export default function Dispute() {
       {data !== undefined && (metaEvidence || error) ? (
         <VotingHistory
           rounds={data.rounds}
-          disptueId={data.id}
+          disputeId={data.id}
           chainId={chainId!}
           metaEvidence={metaEvidence}
         />

--- a/src/pages/Dispute.tsx
+++ b/src/pages/Dispute.tsx
@@ -29,7 +29,7 @@ export default function Dispute() {
     id!
   );
   const exportData = () => {
-    const jsonString = `data:text/json;chatset=utf-8,${encodeURIComponent(
+    const jsonString = `data:text/json;charset=utf-8,${encodeURIComponent(
       JSON.stringify(data)
     )}`;
     const link = document.createElement("a");

--- a/src/pages/Disputes.tsx
+++ b/src/pages/Disputes.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
 import { useDisputes } from "../hooks/useDisputes";
 import { formatDate } from "../lib/helpers";
-import { DataGrid, GridRenderCellParams } from "@mui/x-data-grid";
+import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import { CustomFooter } from "../components/DataGridFooter";
 import { Link as LinkRouter, useLocation } from "react-router-dom";
 import { Link, Typography } from "@mui/material";
-import { BigNumberish } from "../lib/types";
 import Header from "../components/Header";
 import { Court, Dispute } from "../graphql/subgraph";
 import CourtLink from "../components/CourtLink";
@@ -18,13 +17,13 @@ export default function Disputes() {
   const { data: disputes, isLoading } = useDisputes({ chainId: chainId! });
   const [pageSize, setPageSize] = useState<number>(10);
 
-  const columns = [
+  const columns: GridColDef<Dispute>[] = [
      {
        field: "id",
        headerName: "#",
        flex: 1,
        type: "number",
-       renderCell: (params: GridRenderCellParams<string>) => (
+       renderCell: (params: GridRenderCellParams<Dispute, string>) => (
          <Link
            component={LinkRouter}
            to={`/${chainId}/cases/${params.value!}`}
@@ -36,7 +35,7 @@ export default function Disputes() {
        field: "subcourtID",
        headerName: "Court",
        flex: 2,
-      renderCell: (params: GridRenderCellParams<Court>) =>
+      renderCell: (params: GridRenderCellParams<Dispute, Court>) =>
         params.value ? (
           <CourtLink chainId={chainId!} courtId={params.value.id as string} />
         ) : (
@@ -52,7 +51,7 @@ export default function Disputes() {
        field: "period",
        headerName: "Period",
        flex: 1,
-       valueFormatter: (value) => {
+       valueFormatter: (value: any) => {
          return value.charAt(0).toUpperCase() + value.slice(1);
        },
      },
@@ -60,7 +59,7 @@ export default function Disputes() {
        field: "lastPeriodChange",
        headerName: "Last Period Change",
        flex: 1,
-       valueFormatter: (value) => {
+       valueFormatter: (value: any) => {
          return formatDate(value as number);
        },
      },
@@ -75,7 +74,7 @@ export default function Disputes() {
       />
 
        {
-         <DataGrid
+         <DataGrid<Dispute>
            rows={disputes ? disputes! : []}
            columns={columns}
            paginationModel={{ page: 0, pageSize }}

--- a/src/pages/Disputes.tsx
+++ b/src/pages/Disputes.tsx
@@ -4,7 +4,7 @@ import { formatDate } from "../lib/helpers";
 import { DataGrid, GridRenderCellParams } from "@mui/x-data-grid";
 import { CustomFooter } from "../components/DataGridFooter";
 import { Link as LinkRouter, useLocation } from "react-router-dom";
-import { Link } from "@mui/material";
+import { Link, Typography } from "@mui/material";
 import { BigNumberish } from "../lib/types";
 import Header from "../components/Header";
 import { Court, Dispute } from "../graphql/subgraph";
@@ -36,9 +36,12 @@ export default function Disputes() {
        field: "subcourtID",
        headerName: "Court",
        flex: 2,
-       renderCell: (params: GridRenderCellParams<Court>) => (
-         <CourtLink chainId={chainId!} courtId={params.value?.id as string} />
-       ),
+      renderCell: (params: GridRenderCellParams<Court>) =>
+        params.value ? (
+          <CourtLink chainId={chainId!} courtId={params.value.id as string} />
+        ) : (
+          <Typography variant="body2">—</Typography>
+        ),
      },
     {
       field: "currentRulling",

--- a/src/pages/Disputes.tsx
+++ b/src/pages/Disputes.tsx
@@ -82,7 +82,7 @@ export default function Disputes() {
            loading={isLoading}
            onPaginationModelChange={(model) => setPageSize(model.pageSize)}
            pageSizeOptions={[10, 50, 100]}
-           disableSelectionOnClick
+            disableRowSelectionOnClick
            initialState={{
              sorting: { sortModel: [{ field: "id", sort: "desc" }] },
            }}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -48,6 +48,7 @@ export const row_css = {
   borderRadius: "3px",
   margin: "10px 0px",
   paddingTop: "0px",
+  width: "100%",
 };
 
 const blackText = {
@@ -155,7 +156,7 @@ export default function Home() {
         title="Dashboard"
         text="Welcome to Klerosboard! Find metrics and insights about Kleros."
       />
-      <Grid container sx={{ justifyContent: "center", alignItems: "start" }}>
+      <Grid container sx={{ justifyContent: "center", alignItems: "start", width: "100%" }}>
          <Grid container columnSpacing={0} sx={row_css}>
            <Grid size={{ xs: 12, md: 4, lg: 3 }}>
              <StatCard

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -311,10 +311,7 @@ export default function Home() {
                subtitle={`Price change: ${
                  pnkInfo ? (pnkInfo.price_change_24h * 100).toFixed(2) : "..."
                }%`}
-               value={
-                 "$ " +
-                 (pnkInfo ? pnkInfo.total_volume.toLocaleString() : "...  ")
-               }
+                value={pnkInfo ? "$ " + pnkInfo.total_volume.toLocaleString() : undefined}
                image={STATS}
              />
            </Grid>
@@ -324,7 +321,7 @@ export default function Home() {
                subtitle={`ETH = $ ${
                  ethInfo ? ethInfo.current_price.toLocaleString() : "..."
                }`}
-               value={pnkInfo ? "$" + pnkInfo.current_price.toFixed(3) : "..."}
+                value={pnkInfo ? "$" + pnkInfo.current_price.toFixed(3) : undefined}
                image={KLEROS}
              />
            </Grid>
@@ -391,7 +388,7 @@ export default function Home() {
          </Grid>
       </Grid>
 
-       <Grid container spacing={2} style={{ marginTop: "40px" }}>
+       <Grid container spacing={2} sx={{ marginTop: "40px" }}>
          <Grid size={{ xs: 12, md: 6 }}>
            <LatestStakes chainId={chainId!} />
          </Grid>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -359,12 +359,12 @@ export default function Home() {
              />
              <Typography sx={grayText}>Adoption:&nbsp;</Typography>
               <Typography sx={{ ...blackText, display: "flex" }}>
-                {jurorAdoption ? (
-                  jurorAdoption
-                ) : (
-                  <Skeleton variant="circular" width={"10px"} />
-                )}{" "}
-                new jurors
+                 {jurorAdoption !== undefined ? (
+                   jurorAdoption
+                 ) : (
+                   <Skeleton variant="circular" width={"10px"} />
+                 )}{" "}
+                 new jurors
               </Typography>
            </Grid>
             <Grid size={{ xs: 12, md: 3 }} sx={{ alignItems: "center", display: "inline-flex" }}>
@@ -376,13 +376,13 @@ export default function Home() {
              />
              <Typography sx={grayText}>Retention:&nbsp;</Typography>
               <Typography sx={{ ...blackText, display: "flex" }}>
-                {jurorAdoption ? (
-                  ((jurorAdoption! / Number(kcOld!.activeJurors)) * 100).toFixed(
-                    2
-                  ) + "%"
-                ) : (
-                  <Skeleton variant="circular" width={"10px"} />
-                )}
+                 {jurorAdoption !== undefined ? (
+                   ((jurorAdoption / Number(kcOld?.activeJurors ?? 1)) * 100).toFixed(
+                     2
+                   ) + "%"
+                 ) : (
+                   <Skeleton variant="circular" width={"10px"} />
+                 )}
               </Typography>
            </Grid>
          </Grid>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -358,14 +358,14 @@ export default function Home() {
                style={{ marginRight: "15px" }}
              />
              <Typography sx={grayText}>Adoption:&nbsp;</Typography>
-             <Typography sx={blackText} display="flex">
-               {jurorAdoption ? (
-                 jurorAdoption
-               ) : (
-                 <Skeleton variant="circular" width={"10px"} />
-               )}{" "}
-               new jurors
-             </Typography>
+              <Typography sx={{ ...blackText, display: "flex" }}>
+                {jurorAdoption ? (
+                  jurorAdoption
+                ) : (
+                  <Skeleton variant="circular" width={"10px"} />
+                )}{" "}
+                new jurors
+              </Typography>
            </Grid>
             <Grid size={{ xs: 12, md: 3 }} sx={{ alignItems: "center", display: "inline-flex" }}>
              <img
@@ -375,15 +375,15 @@ export default function Home() {
                style={{ marginRight: "15px" }}
              />
              <Typography sx={grayText}>Retention:&nbsp;</Typography>
-             <Typography sx={blackText} display="flex">
-               {jurorAdoption ? (
-                 ((jurorAdoption! / Number(kcOld!.activeJurors)) * 100).toFixed(
-                   2
-                 ) + "%"
-               ) : (
-                 <Skeleton variant="circular" width={"10px"} />
-               )}
-             </Typography>
+              <Typography sx={{ ...blackText, display: "flex" }}>
+                {jurorAdoption ? (
+                  ((jurorAdoption! / Number(kcOld!.activeJurors)) * 100).toFixed(
+                    2
+                  ) + "%"
+                ) : (
+                  <Skeleton variant="circular" width={"10px"} />
+                )}
+              </Typography>
            </Grid>
          </Grid>
       </Grid>

--- a/src/pages/Odds.tsx
+++ b/src/pages/Odds.tsx
@@ -2,7 +2,7 @@ import { Box, Grid, Skeleton, TextField, Typography } from '@mui/material'
 import React, { useEffect, useState } from 'react'
 import Header from '../components/Header'
 import DICE from '../assets/icons/dice_violet.png';
-import { DataGrid, GridRenderCellParams, GridValueFormatterParams } from '@mui/x-data-grid';
+import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import { Court, JurorOdds } from '../graphql/subgraph';
 import CourtLink from '../components/CourtLink';
 import { useLocation } from 'react-router-dom';
@@ -91,49 +91,49 @@ export default function Odds() {
     }
   }, [odds, generalCourtOdds])
 
-  const columns = [
+  const columns: GridColDef<JurorOdds>[] = [
     {
       field: 'id', headerName: 'Court #', flex: 1
     },
     {
-      field: 'subcourtID', headerName: 'Court Name', flex: 2, renderCell: (params: GridRenderCellParams<BigNumberish>) => (
-        <CourtLink chainId={chainId!} courtId={params.value! as string} />
+      field: 'subcourtID', headerName: 'Court Name', flex: 2, renderCell: (params: GridRenderCellParams<JurorOdds>) => (
+        <CourtLink chainId={chainId!} courtId={params.value as string} />
       )
     },
      {
-       field: 'activeJurors', headerName: 'Jurors', type: 'number', valueFormatter: (value) => {
+       field: 'activeJurors', headerName: 'Jurors', type: 'number', valueFormatter: (value: any) => {
          return Number(value)
        }
      },
       {
-        field: 'tokenStaked', headerName: 'Total Staked', flex: 1, valueFormatter: (value) => {
+        field: 'tokenStaked', headerName: 'Total Staked', flex: 1, valueFormatter: (value: any) => {
           const valueFormatted = Number(formatEther(BigInt(String(value as number)))).toLocaleString(undefined, { maximumFractionDigits: 0 });
           return `${valueFormatted}`;
         }
       },
      {
-       field: 'stakeShare', headerName: 'Stake Share', flex: 1, valueFormatter: (value) => {
+       field: 'stakeShare', headerName: 'Stake Share', flex: 1, valueFormatter: (value: any) => {
          const valueFormatted = Number(value * 100).toFixed(2);
          return `${valueFormatted} %`;
        }
      },
      {
-       field: 'odds', headerName: 'Odds', valueFormatter: (value) => {
+       field: 'odds', headerName: 'Odds', valueFormatter: (value: any) => {
          const valueFormatted = Number(value * 100).toFixed(2);
          return `${valueFormatted} %`;
        }
      },
      {
-       field: 'feeForJuror', headerName: 'Fee for Jurors', type:'number', flex: 1, valueFormatter: (value) => {
+       field: 'feeForJuror', headerName: 'Fee for Jurors', type:'number', flex: 1, valueFormatter: (value: any) => {
          return formatAmount(value, chainId!, true, true);
        }
      },
     {
-      field: 'voteStake', headerName: 'Vote Stake', flex: 1, renderCell: (params: GridRenderCellParams<BigNumberish>) => {
+      field: 'voteStake', headerName: 'Vote Stake', flex: 1, renderCell: (params: GridRenderCellParams<JurorOdds>) => {
         return (getVoteStake(params.row.minStake, params.row.alpha).toLocaleString() + ' PNK');
       }
     },
-    { field: 'rewardRisk', headerName: 'Reward/Risk', flex: 1, renderCell: (params: GridRenderCellParams<BigNumberish>) => {
+    { field: 'rewardRisk', headerName: 'Reward/Risk', flex: 1, renderCell: (params: GridRenderCellParams<JurorOdds>) => {
       return (getRewardRisk(params.row.feeForJuror, params.row.voteStake, pnkInfo, chainId!).toFixed(3));
     }}
   ];
@@ -161,7 +161,7 @@ export default function Odds() {
            <TextField id="outlined-basic" value={nJurors} variant="outlined" onChange={handleSetNJuror} sx={formStyle} />
          </Grid>
        </Grid>
-      <Box display={'inline-flex'} margin={'20px 0px 40px'} alignItems={'center'}>
+      <Box sx={{ display: 'inline-flex', margin: '20px 0px 40px', alignItems: 'center' }}>
         <img src={DICE} height='13px' width='13px' alt='dice' style={{marginRight: '10px'}}/>
         <Typography sx={{
           fontStyle: 'normal',
@@ -182,7 +182,7 @@ export default function Odds() {
           : <Skeleton width={'40px'}/>}</Typography>
         </Box>
 
-      {<DataGrid
+      {<DataGrid<JurorOdds>
          rows={odds ? odds! : []}
          columns={columns}
          paginationModel={{ page: 0, pageSize }}

--- a/src/pages/Odds.tsx
+++ b/src/pages/Odds.tsx
@@ -31,7 +31,7 @@ function getRewardRisk(feeForJuror: BigNumberish, voteStake: BigNumberish, pnkEt
   else if (chainId === '100') pnkPrice = pnkEth.current_price
   else return 0
 
-  return Number(formatEther(BigInt(String(feeForJuror)))) / (Number(voteStake) * pnkPrice!); 
+  return Number(formatEther(BigInt(String(feeForJuror)))) / (Number(voteStake) * (pnkPrice ?? 1)); 
 }
 
 const formStyle = {

--- a/src/pages/Odds.tsx
+++ b/src/pages/Odds.tsx
@@ -189,7 +189,7 @@ export default function Odds() {
          loading={isLoading}
          onPaginationModelChange={(model) => setPageSize(model.pageSize)}
          pageSizeOptions={[10, 50, 100]}
-         disableSelectionOnClick
+         disableRowSelectionOnClick
          autoHeight={true}
        />}
 

--- a/src/pages/Solutions.tsx
+++ b/src/pages/Solutions.tsx
@@ -15,7 +15,7 @@ import TOKENS from '../assets/icons_kleros/tokens.png';
 function SolutionCard({ img, text, href }: { img: string, text: string, href?: string }) {
 
   return (
-    <Grid size={{ xs: 12, md: 1 }}
+    <Grid size={{ xs: 6, sm: 3, md: 'grow' }}
       sx={{height: '172px', backgroundColor: '#FFF', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center'}}>
       <a href={href ? href : '/#'} target='_blank' rel="noreferrer"><img src={img} alt={text} /></a>
       <Typography>{text}</Typography>
@@ -30,7 +30,7 @@ export default function Solutions() {
         logo={UNION}
         title='Kleros Solutions'
         text='A list of Kleros Solutions and official links' />
-      <Grid container spacing={2} sx={{justifyContent: 'space-between', alignItems: 'center', marginTop: '-40px'}}>
+      <Grid container spacing={2} sx={{ width: '100%', justifyContent: 'space-between', alignItems: 'center', marginTop: '16px' }}>
         <SolutionCard img={COURT} text='Court' href='https://court.kleros.io' />
         <SolutionCard img={ESCROW} text='Escrow' href='https://escrow.kleros.io' />
         <SolutionCard img={TOKENS} text='Tokens' href='https://tokens.kleros.io'  />

--- a/src/pages/Solutions.tsx
+++ b/src/pages/Solutions.tsx
@@ -16,7 +16,7 @@ function SolutionCard({ img, text, href }: { img: string, text: string, href?: s
 
   return (
     <Grid size={{ xs: 6, sm: 3, md: 'grow' }}
-      sx={{height: '172px', backgroundColor: '#FFF', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center'}}>
+      sx={{ height: '172px', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
       <a href={href ? href : '/#'} target='_blank' rel="noreferrer"><img src={img} alt={text} /></a>
       <Typography>{text}</Typography>
     </Grid>
@@ -30,7 +30,7 @@ export default function Solutions() {
         logo={UNION}
         title='Kleros Solutions'
         text='A list of Kleros Solutions and official links' />
-      <Grid container spacing={2} sx={{ width: '100%', justifyContent: 'space-between', alignItems: 'center', marginTop: '16px' }}>
+      <Grid container spacing={2} sx={{ width: '100%', alignItems: 'stretch' }}>
         <SolutionCard img={COURT} text='Court' href='https://court.kleros.io' />
         <SolutionCard img={ESCROW} text='Escrow' href='https://escrow.kleros.io' />
         <SolutionCard img={TOKENS} text='Tokens' href='https://tokens.kleros.io'  />

--- a/src/pages/Stakes.tsx
+++ b/src/pages/Stakes.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { formatAmount, formatDate, formatPNK } from '../lib/helpers';
 import {
-  DataGrid, GridRenderCellParams,
+  DataGrid, GridColDef, GridRenderCellParams,
 } from '@mui/x-data-grid'
 import { CustomFooter } from '../components/DataGridFooter'
 import { Link } from '@mui/material';
@@ -9,7 +9,7 @@ import { Link as LinkRouter, useLocation } from 'react-router-dom';
 import { BigNumberish } from '../lib/types';
 import Header from '../components/Header';
 import { useStakes } from '../hooks/useStakes';
-import { Juror } from '../graphql/subgraph';
+import { Juror, StakeSet } from '../graphql/subgraph';
 import { shortenAddress } from '../lib/utils';
 import CourtLink from '../components/CourtLink';
 import STAKES from '../assets/icons/icosahedron_violet.png';
@@ -22,15 +22,15 @@ export default function Stakes() {
   const { data: stakes, isLoading } = useStakes({chainId:chainId!});
   const [pageSize, setPageSize] = useState<number>(10);
 
-   const columns = [
+   const columns: GridColDef<StakeSet>[] = [
      {
-       field: 'address', headerName: 'Juror', flex: 1, renderCell: (params: GridRenderCellParams<Juror>) => (
+       field: 'address', headerName: 'Juror', flex: 1, renderCell: (params: GridRenderCellParams<StakeSet, { id: string }>) => (
          <Link component={LinkRouter} to={`/${chainId}/profile/` + params.value!.id} children={shortenAddress(params.value!.id)} />
        )
      },
      {
-       field: 'subcourtID', headerName: 'Court Name', flex: 2, renderCell: (params: GridRenderCellParams<BigNumberish>) => (
-         <CourtLink chainId={chainId!} courtId={params.value! as string} />
+       field: 'subcourtID', headerName: 'Court Name', flex: 2, renderCell: (params: GridRenderCellParams<StakeSet>) => (
+         <CourtLink chainId={chainId!} courtId={params.value as string} />
        )
      },
      {
@@ -65,7 +65,7 @@ export default function Stakes() {
       />
 
 
-       {<DataGrid
+       {<DataGrid<StakeSet>
          rows={stakes ? stakes! : []}
          columns={columns}
          paginationModel={{ page: 0, pageSize }}

--- a/src/pages/Stakes.tsx
+++ b/src/pages/Stakes.tsx
@@ -72,12 +72,11 @@ export default function Stakes() {
          loading={isLoading}
         onPaginationModelChange={(model) => setPageSize(model.pageSize)}
         pageSizeOptions={[10, 50, 100]}
-        pagination
         disableSelectionOnClick
-        autoHeight={true}
-        components={{
-          Footer: CustomFooter
-        }}
+         autoHeight={true}
+         slots={{
+           footer: CustomFooter
+         }}
       />}
 
     </div>

--- a/src/pages/Stakes.tsx
+++ b/src/pages/Stakes.tsx
@@ -72,7 +72,7 @@ export default function Stakes() {
          loading={isLoading}
         onPaginationModelChange={(model) => setPageSize(model.pageSize)}
         pageSizeOptions={[10, 50, 100]}
-        disableSelectionOnClick
+         disableRowSelectionOnClick
          autoHeight={true}
          slots={{
            footer: CustomFooter

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+declare module '*.svg?react' {
+  import React from 'react';
+  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  export default ReactComponent;
+}


### PR DESCRIPTION
## Summary

Post-migration aesthetic and functional fixes after the MUI v9 + TanStack Query v5 + viem refactor. Covers grid layout regressions, deprecated DataGrid API usage, hardcoded loading strings, and a critical bug in the dynamic script sandbox for governor disputes.

## Changes

### Grid / Layout
- Add `width: '100%'` to outer Grid containers in Home, AggregatedCharts, Court, Dispute, VotePanel
- `row_css` missing `width: '100%'` — affected all stat card rows in Home and AggregatedCharts
- Grid items without `size` prop (collapsed to 0-width in MUI v9): Court, RoundPanel, CaseInfo, VotePanel
- CaseInfo: Creator section `md:12` → `md:6`, add `gap` and `alignItems` to Court/Date/Round rows
- VotePanel: vote choice item gets `size='grow'`, Vote/Date labels wrapped in `Box` with `gap`
- Solutions: cards were `md:1` (8% width) → `size='grow'` for equal distribution
- RowLinks: `display:inline-flex` → `width:'100%'` so rows fill container

### DataGrid API (MUI X v9)
- `disableSelectionOnClick` → `disableRowSelectionOnClick` in 10 files (was silently ignored)
- `components` → `slots` in LatestDisputes, LatestStakes, Stakes
- Removed orphan `pagination` prop from Stakes (removed in v9)
- Download JSON link in Dispute: `inline-flex + marginLeft:auto` → `flex + justifyContent:flex-end`

### Loading strings
- Arbitrables name column: `'Loading...'` frozen string → `<Skeleton>` reactive renderCell
- Home PNK stats: `'...'` fallback → `undefined` so StatCard shows its own Skeleton
- Arbitrable detail title: `'Loading...'` → `id` as fallback

### Type / import fixes
- Import path `../../lib/types` → `../lib/types` in LatestStakes and StatCard
- Typo `disptueId` → `disputeId` in VotingHistory + Dispute
- `style={}` → `sx={}` on Grid components in Home and Court
- CSS bare props moved to `sx` in ProfileStats (`minHeight`), Dispute (`display`, `marginLeft`, `textAlign`)

### Data / query fixes
- `useDisputes` queryKey missing `creator` → Profile page was showing ALL disputes instead of filtering by creator (TanStack Query cache collision)

### Dynamic script sandbox
- `getMetaEvidence()` in governor scripts returns a Promise, not a direct value
- Sandbox was calling `resolveScript(promise)` — serialized as `{}`, so `rulingOptions.titles` never resolved
- Fix: detect `.then` and chain properly → vote titles now show correctly (e.g. `List 9`, `List 10`)

## Test plan
- [x] `yarn build` passes with no new errors
- [x] Home: stat cards fill 100% width, Skeleton shows while loading
- [x] Disputes (/cases): Court column shows names, no infinite Skeleton
- [x] Dispute detail (/cases/1675): vote titles resolve correctly (`List 9`, `List 10`)
- [x] Solutions: 8 cards distributed evenly in one row, RowLinks full width
- [x] Profile: CreatedCases shows only cases created by the juror
