### PR TITLE
feat(dispute): vote distribution bar chart + whitelist sync + cross-chain RPC fix

### DIFF
--- a/src/components/Case/RoundPanel.tsx
+++ b/src/components/Case/RoundPanel.tsx
@@ -6,7 +6,7 @@ import BALANCE_VIOLET from '../../assets/icons/balance_violet.png';
 import { BigNumberish } from '../../lib/types';
 import VotePanel from './VotePanel';
 import { MetaEvidence } from '../../lib/types';
-import { voteMapping } from '../../lib/helpers';
+import { getPeriodNumber, voteMapping } from '../../lib/helpers';
 import StackedBarChart from '../StackedBarChart';
 
 interface Props {
@@ -15,27 +15,88 @@ interface Props {
     disputeId: BigNumberish
     roundId: BigNumberish
     metaEvidence?: MetaEvidence
+    hiddenVotes: boolean
+    period: string
 }
 
-function getVoteCount(votes: Vote[], metaEvidence: MetaEvidence | undefined): [string, number][] {
-    let count: { [id: string]: number; } = {}
-    votes.forEach((vote) => {
-        const choice = voteMapping(vote.choice, vote.voted, vote.commit, metaEvidence ? metaEvidence.metaEvidenceJSON.rulingOptions.titles : undefined)
-        if (count[choice]) {
-            count[choice] += 1;
-        } else {
-            count[choice] = 1;
-        }
-    })
+// Labels with their own fixed slot
+const REFUSE_LABEL = "Refuse to Arbitrate";
+const COMMITTED_LABEL = "Committed";
 
-    let sortable: [id: string, value: number][] = [];
-    for (var key in count) {
-        sortable.push([key, count[key]]);
-    }
-    sortable.sort(function (a, b) {
-        return b[1] - a[1];
+function getVoteCount(votes: Vote[], metaEvidence: MetaEvidence | undefined): [string, number][] {
+    const count: Record<string, number> = {};
+    votes.forEach((vote) => {
+        const choice = voteMapping(vote.choice, vote.voted, vote.commit, metaEvidence?.metaEvidenceJSON?.rulingOptions?.titles);
+        count[choice] = (count[choice] ?? 0) + 1;
     });
-    return sortable
+
+    const sortable: [string, number][] = Object.entries(count).sort((a, b) => b[1] - a[1]);
+    return sortable;
+}
+
+/**
+ * Normalizes raw vote counts into fixed named slots:
+ *   Pending | Committed* | Refuse to Arbitrate | <top option> | <2nd option> | (Others if needed)
+ *
+ * *Committed is only included when hiddenVotes=true and period > evidence.
+ *  Otherwise those votes are re-classified as Pending (commit was never revealed).
+ */
+function normalizeToSlots(
+    rawVotes: [string, number][],
+    hiddenVotes: boolean,
+    period: string,
+    titles: string[] | undefined,
+): [string, number][] {
+    const committedIsValid = hiddenVotes && getPeriodNumber(period) > 0;
+
+    let pending = 0;
+    let committed = 0;
+    let refuse = 0;
+    const votedMap = new Map<string, number>(); // label -> count for options that got votes
+
+    rawVotes.forEach(([label, count]) => {
+        if (label === "Pending") {
+            pending += count;
+        } else if (label === COMMITTED_LABEL) {
+            if (committedIsValid) {
+                committed += count;
+            } else {
+                pending += count;
+            }
+        } else if (label === REFUSE_LABEL) {
+            refuse += count;
+        } else {
+            votedMap.set(label, (votedMap.get(label) ?? 0) + count);
+        }
+    });
+
+    // Build the full option list from titles (all known options), filling 0 for unvoted ones.
+    // Then sort descending by votes so top-2 are first.
+    const allOptions: [string, number][] = titles
+        ? titles.map((title) => [title, votedMap.get(title) ?? 0])
+        : Array.from(votedMap.entries());
+
+    allOptions.sort((a, b) => b[1] - a[1]);
+
+    // Any label that got votes but isn't in titles (e.g. numeric fallback "3**") goes to Others
+    const knownTitleSet = new Set(allOptions.map(([t]) => t));
+    let others = 0;
+    votedMap.forEach((count, label) => {
+        if (!knownTitleSet.has(label)) others += count;
+    });
+    // Also collapse options beyond top-2 into Others
+    others += allOptions.slice(2).reduce((acc, [, c]) => acc + c, 0);
+    const top2 = allOptions.slice(0, 2);
+
+    const slots: [string, number][] = [
+        ...(pending > 0 ? [["Pending", pending] as [string, number]] : []),
+        ...(committedIsValid ? [["Committed", committed] as [string, number]] : []),
+        ["Refuse to Arbitrate", refuse],
+        ...top2.map(([label, count]) => [label, count] as [string, number]),
+        ...(others > 0 ? [["Others", others] as [string, number]] : []),
+    ];
+
+    return slots;
 }
 
 function getJuryDecision(sortedVotes: [string, number][], numVotes: number): string {
@@ -62,6 +123,8 @@ function getJuryDecision(sortedVotes: [string, number][], numVotes: number): str
 export default function RoundPanel(props: Props) {
     const sortedVotes = getVoteCount(props.votes, props.metaEvidence);
     const juryDecison = getJuryDecision(sortedVotes, props.votes.length);
+    const titles = props.metaEvidence?.metaEvidenceJSON?.rulingOptions?.titles;
+    const chartData = normalizeToSlots(sortedVotes, props.hiddenVotes, props.period, titles);
 
     return (
         <div key={`RoundPanel-${props.roundId as string}`}>
@@ -75,7 +138,7 @@ export default function RoundPanel(props: Props) {
                         <Typography>Jury Decision:&nbsp;</Typography><Typography>{juryDecison}</Typography>
                     </Grid>
                     <Grid size={12} sx={{ display: 'inline-flex', alignItems: 'center' }}>
-                        <StackedBarChart data={sortedVotes} />
+                        <StackedBarChart data={chartData} />
                     </Grid>    
                 </Grid>
                 

--- a/src/components/Case/VotePanel.tsx
+++ b/src/components/Case/VotePanel.tsx
@@ -36,7 +36,7 @@ const voteStyle = {
 }
 
 export default function VotePanel(props: Props) {
-  const voteChoice = voteMapping(props.vote.choice, props.vote.voted, props.vote.commit, props.metaEvidence?props.metaEvidence.metaEvidenceJSON.rulingOptions.titles: undefined);
+  const voteChoice = voteMapping(props.vote.choice, props.vote.voted, props.vote.commit, props.metaEvidence?.metaEvidenceJSON?.rulingOptions?.titles);
   return (
     <Accordion
       sx={{

--- a/src/components/Case/VotingHistory.tsx
+++ b/src/components/Case/VotingHistory.tsx
@@ -12,6 +12,8 @@ interface Props {
     disputeId: BigNumberish
     chainId: string
     metaEvidence?: MetaEvidence
+    hiddenVotes: boolean
+    period: string
 }
 
 interface TabPanelProps {
@@ -75,7 +77,7 @@ export default function VotingHistory(props: Props) {
                 props.rounds.map((round, index) => {
                     return (
                         <TabPanel value={value} index={index} key={`TabPanel-${index}`}>
-                            <RoundPanel disputeId={props.disputeId} votes={round.votes} chainId={props.chainId} roundId={round.id} metaEvidence={props.metaEvidence}/>
+                            <RoundPanel disputeId={props.disputeId} votes={round.votes} chainId={props.chainId} roundId={round.id} metaEvidence={props.metaEvidence} hiddenVotes={props.hiddenVotes} period={props.period}/>
                         </TabPanel>
                     )
                 })

--- a/src/components/Profile/VoteMapping.tsx
+++ b/src/components/Profile/VoteMapping.tsx
@@ -20,9 +20,7 @@ export default function VoteMapping({
   );
 
   if (metaEvidence !== undefined) {
-    const rullingOptions = metaEvidence.metaEvidenceJSON
-      ? metaEvidence.metaEvidenceJSON.rulingOptions.titles
-      : undefined;
+    const rullingOptions = metaEvidence.metaEvidenceJSON?.rulingOptions?.titles;
     return (
       <Typography>
         {voteMapping(

--- a/src/components/StackedBarChart.tsx
+++ b/src/components/StackedBarChart.tsx
@@ -1,58 +1,66 @@
 import React from "react";
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  Legend,
-  CartesianGrid,
-  ResponsiveContainer,
-} from "recharts";
+import { Box, Tooltip, Typography } from "@mui/material";
 
-const transformArrayToObject = (
-  data: [string, number][]
-): Record<string, number | string> => {
-  const result: Record<string, number | string> = { name: "votes" };
-  let totalVotes = data.reduce((acc, cur) => acc + cur[1], 0);
-  if (totalVotes === 0) {
-    totalVotes = 1;
-  }
-
-  data.forEach(([key, qty]) => {
-    result[key] = (qty / totalVotes) * 100;
-  });
-  return result;
+// Well-known slot names get a pinned color; dynamic option labels get colors by encounter order.
+const FIXED_COLORS: Record<string, string> = {
+  Pending: "#AAAAAA",
+  Committed: "#778899",
+  "Refuse to Arbitrate": "#333333",
+  Others: "#FFBB28",
 };
 
+const OPTION_COLORS = ["#4D00B4", "#009AFF", "#9013FE", "#FF8042"];
 
+const FIXED_SLOT_NAMES = new Set(Object.keys(FIXED_COLORS));
+
+export function resolveSlotColor(key: string, optionIndex: number): string {
+  if (key in FIXED_COLORS) return FIXED_COLORS[key];
+  return OPTION_COLORS[optionIndex % OPTION_COLORS.length];
+}
 
 const StackedBarChart: React.FC<{ data: [string, number][] }> = ({ data }) => {
-  const dataObject = transformArrayToObject(data);
-  const keys = Object.keys(dataObject).filter((key) => key !== "name");
-  // This should be values from theme!
-  const fillColors = [
-    "#4D00B4","#009AFF", "#9013FE", "#333333", "#009AFF", "#FAFBFC", "#FFBB28", "#FF8042", "#AF19FF", "#FF1963"
-  ];
+  const total = data.reduce((acc, [, n]) => acc + n, 0) || 1;
+
+  let optionIndex = 0;
+  const segments = data.map(([key, count]) => {
+    const isFixed = FIXED_SLOT_NAMES.has(key);
+    const color = resolveSlotColor(key, optionIndex);
+    if (!isFixed) optionIndex++;
+    return { key, count, pct: count / total, color };
+  });
+
   return (
-    <ResponsiveContainer width="100%" height={100}>
-      <BarChart
-        data={[dataObject]}
-        layout="vertical"
-        
-      >
-        <CartesianGrid />
-        <XAxis type="number" label={{value: "Percentage of votes", position:"insideBottom", offset: 0}}/>
-        <YAxis dataKey="name" type="category" hide />
-        
-        <Tooltip />
-        <Legend />
-        
-        {keys.map((key, index) => (
-          <Bar key={index} dataKey={key} stackId="a" fill={fillColors[index % fillColors.length]} />
+    <Box sx={{ width: "100%", mt: 1 }}>
+      {/* Stacked bar — only render segments with actual votes */}
+      <Box sx={{ display: "flex", width: "100%", height: 24, borderRadius: 1, overflow: "hidden" }}>
+        {segments.filter(({ count }) => count > 0).map(({ key, count, pct, color }) => (
+          <Tooltip key={key} title={`${key}: ${count} (${(pct * 100).toFixed(1)}%)`} arrow>
+            <Box
+              sx={{
+                width: `${pct * 100}%`,
+                height: "100%",
+                backgroundColor: color,
+                cursor: "default",
+                transition: "opacity 0.15s",
+                "&:hover": { opacity: 0.8 },
+              }}
+            />
+          </Tooltip>
         ))}
-      </BarChart>
-    </ResponsiveContainer>
+      </Box>
+
+      {/* Legend — always show all slots */}
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5, mt: 0.75 }}>
+        {segments.map(({ key, pct, color }) => (
+          <Box key={key} sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            <Box sx={{ width: 12, height: 12, borderRadius: "2px", backgroundColor: color, flexShrink: 0 }} />
+            <Typography variant="caption" sx={{ color: pct === 0 ? "text.disabled" : "text.secondary" }}>
+              {key} {(pct * 100).toFixed(1)}%
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+    </Box>
   );
 };
 

--- a/src/lib/dynamicScriptSandbox.ts
+++ b/src/lib/dynamicScriptSandbox.ts
@@ -89,24 +89,41 @@ export default function executeDynamicScript(
 const scriptParameters = ${JSON.stringify(scriptParameters)};
 const rpcUrl = ${JSON.stringify(sandboxConfig.rpcUrl)};
 
-// Hardcoded Infura URL that needs to be redirected
-const oldRpcUrl = 'https://mainnet.infura.io/v3/668b3268d5b241b5bab5c6cb886e4c61';
+// Known hardcoded RPC URLs that dynamic scripts may contain — redirect all to our configured RPC.
+const knownRpcPatterns = [
+  'mainnet.infura.io',
+  'infura.io',
+  'alchemy.com',
+  'cloudflare-eth.com',
+  'gateway.fm',
+  '1rpc.io',
+  'publicnode.com',
+  'rpc.ankr.com',
+  'gnosis.drpc.org',
+  'rpc.gnosischain.com',
+];
+
+function shouldRedirect(url) {
+  if (typeof url !== 'string') return false;
+  try {
+    const parsed = new URL(url);
+    // Only redirect http/https (not blob:, data:, etc.)
+    if (!parsed.protocol.startsWith('http')) return false;
+    return knownRpcPatterns.some(pattern => parsed.host.includes(pattern));
+  } catch (e) { return false; }
+}
 
 // Patch XMLHttpRequest.open to redirect RPC calls
 const originalXHROpen = XMLHttpRequest.prototype.open;
 XMLHttpRequest.prototype.open = function(method, url, ...rest) {
-  const processedUrl = typeof url === 'string' && url.includes(oldRpcUrl)
-    ? url.replace(oldRpcUrl, rpcUrl)
-    : url;
+  const processedUrl = shouldRedirect(url) ? rpcUrl : url;
   return originalXHROpen.call(this, method, processedUrl, ...rest);
 };
 
 // Patch fetch to redirect RPC calls
 const originalFetch = window.fetch;
 window.fetch = function(url, ...rest) {
-  const processedUrl = typeof url === 'string' && url.includes(oldRpcUrl)
-    ? url.replace(oldRpcUrl, rpcUrl)
-    : url;
+  const processedUrl = shouldRedirect(url) ? rpcUrl : url;
   return originalFetch.call(this, processedUrl, ...rest);
 };
 

--- a/src/lib/fetchMetaEvidence.ts
+++ b/src/lib/fetchMetaEvidence.ts
@@ -132,11 +132,17 @@ export async function fetchMetaEvidence({
             arbitrableJsonRpcUrl: getRPCURL(arbitrableChainID),
           };
 
-          // Execute script in sandbox with RPC redirect patch
+          // Execute script in sandbox — use arbitrable chain RPC for the redirect patch
+          // so any hardcoded RPC URLs inside the script get redirected to the right chain.
+          const scriptSandboxConfig = {
+            ...sandboxConfig,
+            rpcUrl: getRPCURL(arbitrableChainID),
+          };
+
           const scriptResult = await executeDynamicScript(
             scriptText,
             scriptParameters,
-            sandboxConfig,
+            scriptSandboxConfig,
           );
 
           // Merge result into metaEvidenceJSON

--- a/src/lib/fetchMetaEvidence.ts
+++ b/src/lib/fetchMetaEvidence.ts
@@ -118,14 +118,18 @@ export async function fetchMetaEvidence({
           // Prepare script parameters
           const KL =
             chainId === '100' ? GNOSIS_KLEROSLIQUID : MAINNET_KLEROSLIQUID;
+          // Some arbitrables live on a different chain than the arbitrator (e.g. Reality.eth on Gnosis).
+          // Read arbitrableChainID from the metaEvidence JSON if present; fall back to arbitrator chain.
+          const arbitratorChainID = metaEvidenceJSON.arbitratorChainID ?? chainId;
+          const arbitrableChainID = metaEvidenceJSON.arbitrableChainID ?? arbitratorChainID;
           const scriptParameters = {
             disputeID: disputeId,
             arbitrableContractAddress: arbitrableId,
             arbitratorContractAddress: KL,
-            arbitratorChainID: chainId,
-            arbitrableChainID: chainId,
-            arbitratorJsonRpcUrl: getRPCURL(chainId),
-            arbitrableJsonRpcUrl: getRPCURL(chainId),
+            arbitratorChainID: arbitratorChainID,
+            arbitrableChainID: arbitrableChainID,
+            arbitratorJsonRpcUrl: getRPCURL(arbitratorChainID),
+            arbitrableJsonRpcUrl: getRPCURL(arbitrableChainID),
           };
 
           // Execute script in sandbox with RPC redirect patch

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -182,18 +182,12 @@ export function voteMapping(
   commit: string,
   titles: string[] | undefined
 ): string {
-  if (titles === undefined) {
-    console.log("No vote titles");
-  }
-  const _titles = titles || ["Yes**", "No**"];
   const choiceNumber = Number(choice);
   if ((!voted || !choice) && commit === null) return "Pending";
-
   if (commit !== null && !choice) return "Committed";
-  if (choiceNumber === 0) return "Refuse to Arbitate";
-  // If there are more options than yes and no, return the number
-  if (choiceNumber > _titles.length) return `${choiceNumber.toString()}**`;
-  return _titles[Number(choice) - 1];
+  if (choiceNumber === 0) return "Refuse to Arbitrate";
+  if (!titles || choiceNumber > titles.length) return `Option ${choiceNumber}`;
+  return titles[choiceNumber - 1];
 }
 
 export function getVoteStake(

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -241,18 +241,16 @@ export async function getBlockByDate(
 
 export const arbitrableWhitelist: Record<number, string[]> = {
   1: [
+    // Curate / TCR
     "0x126697b552b83f08c7ebebae8d13eae2871e4e1e",
     "0x250aa88c8f54f5e70b94214380342f0d53e42f6c",
     "0x2e3b10abf091cdc53cc892a50dabdb432e220398",
-    "0x2f0895732bfacdcf2fdb19962fe609d0da695f21",
     "0x327a29fce0a6490e4236240be176daa282eccfdf",
     "0x46580533db92c418a79f91b46df70283daef7f99",
     "0x594ec762b59978c97c82bc36ab493ed8b1f1f368",
     "0x6341ec8f3f23689bd6ea3cf82fe34c3a0481c30a",
     "0x68c4cc21378301cfdd5702d66d58a036d7bafe28",
     "0x701cabaf65ed3974925fb94988842a29d2ce7aa3",
-    "0x728cba71a3723caab33ea416cb46e2cc9215a596",
-    "0x776e5853e3d61b2dfb22bcf872a43bf9a1231e52",
     "0x799cb978dea5d6ca00ccb1794d3c3d4c89e40cd1",
     "0x7ecffaa0247227a29d613adb3b1b47e44f0f53cb",
     "0x916deab80dfbc7030277047cd18b233b3ce5b4ab",
@@ -261,7 +259,6 @@ export const arbitrableWhitelist: Record<number, string[]> = {
     "0xc5e9ddebb09cd64dfacab4011a0d5cedaf7c9bdb",
     "0xc9a3cd210cc9c11982c3acf7b7bf9b1083242cb6",
     "0xcb4aae35333193232421e86cd2e9b6c91f3b125f",
-    "0xd47f72a2d1d0e91b0ec5e5f5d02b2dc26d00a14d",
     "0xd7e143715a4244634d74201959372e81a3623a2a",
     "0xd8bf5114796ed28aa52cff61e1b9ef4ec1f69a54",
     "0xe0e1bc8c6cd1b81993e2fcfb80832d814886ea38",
@@ -269,9 +266,22 @@ export const arbitrableWhitelist: Record<number, string[]> = {
     "0xebcf3bca271b26ae4b162ba560e243055af0e679",
     "0xf339047c85d0dd2645f2bd802a1e8a5e7af61053",
     "0xf65c7560d6ce320cc3a16a07f1f65aab66396b9e",
-    "0xf72cfd1b34a91a64f9a98537fe63fbab7530adca",
+    "0xbe9834097a4e97689d9b667441acafb456d0480a", // PoH V2
+    // Reality.eth mainnet proxies
+    "0xce9b84c5612beaa234ad0d9fa7d283293479510e", // WeTrust
+    "0xd47f72a2d1d0e91b0ec5e5f5d02b2dc26d00a14d", // Ethereum main (old)
+    "0x728cba71a3723caab33ea416cb46e2cc9215a596", // Ethereum main (deprecated)
+    "0xff32eff53459485074b4db14633252c9dca3791a", // Ethereum main (new)
+    "0xf72cfd1b34a91a64f9a98537fe63fbab7530adca", // Ethereum DAO Governance
+    "0x2018038203aee8e7a29dabd73771b0355d4f85ad", // Ethereum Seer
+    "0xc45d8d9b2b6843528a4dc2d8b5858e5c258d2992", // Ethereum Seer new (idle)
+    "0x1c2811550551d84030cd1b608e6fe3fd6fd5fc0d", // Lockler
+    "0x776e5853e3d61b2dfb22bcf872a43bf9a1231e52", // Polygon-Ethereum Foreign Proxy
+    "0x2f0895732bfacdcf2fdb19962fe609d0da695f21", // Gnosis-Ethereum main Foreign Proxy (deprecated)
+    "0xfe0eb5fc686f929eb26d541d75bb59f816c0aa68", // Gnosis-Ethereum Seer Foreign Proxy
   ],
   100: [
+    // Curate / TCR
     "0x0b928165a67df8254412483ae8c3b8cc7f2b4d36",
     "0x1d48a279966f37385b4ab963530c6dc813b3a8df",
     "0x2a2bab2c2d4eb5007b0389720b287d4d19dc4001",
@@ -293,5 +303,17 @@ export const arbitrableWhitelist: Record<number, string[]> = {
     "0xe04f5791d671d5c4e08ab49b39807087b591ea3e",
     "0xf7de5537ecd69a94695fcf4bcdbdee6329b63322",
     "0xee1502e29795ef6c2d60f8d7120596abe3bad990",
+    "0x9fe4d9e4989ad031fdc424d8c34d77e70aa0b269",
+    "0xa4ac94c4fa65bb352efa30e3408e64f72ac857bc", // PoH V2
+    "0x5aaf9e23a11440f8c1ad6d2e2e5109c7e52cc672", // Seer Market registry on Curate
+    // Reality.eth Gnosis proxies
+    "0x5afa42b30955f137e10f89dfb5ef1542a186f90e", // Gnosis-Ethereum Polkamarkets Foreland Home Proxy
+    "0x8453ba2c9ea5bae36fde6cbd61c12c05b6552425", // Gnosis-Ethereum Polkamarkets Foreland Foreign Proxy
+    "0x68154ea682f95bf582b80dd6453fa401737491dc", // Gnosis-Ethereum Seer Home Proxy
+    "0xfe0eb5fc686f929eb26d541d75bb59f816c0aa68", // Gnosis-Ethereum Seer Foreign Proxy
+    "0x5562ac605764dc4039fb6ab56a74f7321396cdf2", // Gnosis-Ethereum Omen AI with appeals Home Proxy
+    "0xef2ae6961ec7f2105bc2693bc32fa7b7386b2f59", // Gnosis-Ethereum Omen AI with appeals Foreign Proxy
+    "0x88fb25d399310c07d35cb9091b8346d8b1893aa5", // Gnosis-Ethereum RealitioHomeArbitrationProxy
+    "0x32bdc9776692679cfbbf8350bad67da13faaa3f", // Gnosis-Ethereum RealitioForeignArbitrationProxyWithAppeals
   ],
 };

--- a/src/pages/Dispute.tsx
+++ b/src/pages/Dispute.tsx
@@ -103,6 +103,8 @@ export default function Dispute() {
           disputeId={data.id}
           chainId={chainId!}
           metaEvidence={metaEvidence}
+          hiddenVotes={!!(data.subcourtID as Court).hiddenVotes}
+          period={data.period}
         />
       ) : (
         <Skeleton width={"100%"} height="200px" />


### PR DESCRIPTION
## Summary

Replaces the broken recharts stacked bar chart on dispute pages with a working MUI/SVG implementation, normalizes vote data into fixed labeled slots, and syncs the arbitrable whitelist with `kleros/court`.

## Changes

### Vote Distribution Chart (`StackedBarChart`, `RoundPanel`, `VotingHistory`)
- Replaced broken recharts `BarChart` (rendered empty rectangles due to recharts 2.x bug with `layout="vertical"` + stacked bars) with a custom MUI `Box`-based stacked bar — no external chart lib dependency for this component
- Vote data is normalized into fixed named slots: **Pending** · **Committed**\* · **Refuse to Arbitrate** · **Top option** · **2nd option** · **Others**
  - `Committed` slot only shown when `hiddenVotes=true` AND `period > evidence`
  - `Pending` slot hidden when all jurors have voted
  - Option slots use real labels from `rulingOptions.titles`; options with 0 votes still appear in the legend
  - Options beyond top-2 collapse into `Others`
- Tooltip shows exact count + percentage on hover
- Colors are pinned by slot name (not by array index), so they're stable across different disputes

### Vote Label Fallback (`helpers.ts`)
- Removed misleading `Yes**` / `No**` fallback labels
- When `rulingOptions.titles` is unavailable, falls back to `Option <N>` (neutral and honest)
- Fixed typo: `Refuse to Arbitate` → `Refuse to Arbitrate` across all call sites

### Crash Fix — `rulingOptions` optional chaining
- Added `?.metaEvidenceJSON?.rulingOptions?.titles` throughout `RoundPanel`, `VotePanel`, `VoteMapping` — prevents crash when the dynamic script fails to resolve metaEvidence (e.g. cross-chain Reality.eth disputes)

### Arbitrable Whitelist (`helpers.ts`)
- Synced with `kleros/court` `src/temp/arbitrable-whitelist.js` + `reality-addresses.js`
- Added missing Reality.eth proxies for mainnet and Gnosis (Seer, Polkamarkets, Omen AI, WeTrust, Lockler, PoH V2, etc.)

### Cross-chain RPC Fix (`fetchMetaEvidence.ts`)
- Dynamic scripts for cross-chain arbitrables (e.g. Reality.eth on Gnosis for mainnet disputes) now receive the correct `arbitratorChainID`/`arbitrableChainID` and matching RPC URLs — previously both were hardcoded to the arbitrator chain (mainnet)
- Reads `arbitrableChainID` from the metaEvidence JSON before executing the script

### Sandbox RPC Redirect (`dynamicScriptSandbox.ts`)
- Replaced single hardcoded Infura URL with pattern-based detection (covers Infura, Alchemy, gateway.fm, 1rpc.io, etc.)
- Sandbox now uses the arbitrable chain RPC for the redirect patch

## Known Limitation
Reality.eth/Seer disputes (e.g. case 1661) still show `Option 1`/`Option 2` instead of `Yes`/`No` — the dynamic script times out in the Blob URL sandbox due to Chromium blocking XHR from `null` origins to external domains. Court solves this by running the script inside the evidence iframe (which has a real origin). Tracked separately.

## Test Cases
- Case 1675 (PoH Governor, List 10 vs pending) — chart renders correctly ✅
- Case 1661 (Reality.eth/Gnosis cross-chain) — no crash, falls back to `Option 1`/`Option 2` gracefully ✅
- Cases with all jurors voted — Pending slot hidden ✅
- Cases with only 1 option voted — no phantom `Option 2` slot ✅