### PR TITLE
fix(sandbox): two-phase metaEvidence fetch — no timeout for dynamic scripts

### DIFF
--- a/src/components/Case/CaseInfo.tsx
+++ b/src/components/Case/CaseInfo.tsx
@@ -26,6 +26,7 @@ interface Props {
   startTimestamp: BigNumberish;
   roundNum: number;
   metaEvidence?: MetaEvidence;
+  isDynamicScriptLoading?: boolean;
 }
 
 const normalizeIPFSUri = (uri: string) =>

--- a/src/components/Case/RoundPanel.tsx
+++ b/src/components/Case/RoundPanel.tsx
@@ -1,4 +1,4 @@
-import { Grid, Typography } from '@mui/material'
+import { CircularProgress, Grid, Tooltip, Typography } from '@mui/material'
 import React from 'react'
 import { Vote } from '../../graphql/subgraph'
 import USER_VIOLET from '../../assets/icons/user_violet.png';
@@ -15,6 +15,7 @@ interface Props {
     disputeId: BigNumberish
     roundId: BigNumberish
     metaEvidence?: MetaEvidence
+    isDynamicScriptLoading?: boolean
     hiddenVotes: boolean
     period: string
 }
@@ -100,10 +101,10 @@ function normalizeToSlots(
 }
 
 function getJuryDecision(sortedVotes: [string, number][], numVotes: number): string {
-    const options = sortedVotes.map(([option, _]) => option);
+    const options = sortedVotes.map(([option]) => option);
 
     if (options.every(option => option === 'Pending')) {
-    return "Pending decision";
+        return "Pending decision";
     }
 
     const pendingOrCommitted = options.every(option => option === "Pending" || option === "Committed");
@@ -111,13 +112,16 @@ function getJuryDecision(sortedVotes: [string, number][], numVotes: number): str
         return "Decision to be revealed";
     }
 
-    const maxVotes = sortedVotes[0][1];
-    const tied = sortedVotes.filter(([_, votes]) => votes === maxVotes).length > 1;
+    // Exclude non-votes (Pending / Committed) — they don't count as a ruling option.
+    const actualVotes = sortedVotes.filter(([label]) => label !== "Pending" && label !== COMMITTED_LABEL);
+
+    const maxVotes = actualVotes[0][1];
+    const tied = actualVotes.filter(([, votes]) => votes === maxVotes).length > 1;
     if (tied) {
         return "Tied";
     }
 
-    return `${sortedVotes[0][0]} with ${sortedVotes[0][1]} votes (${(Number(sortedVotes[0][1]) / numVotes * 100).toPrecision(3)}%)`; // The option with the most votes
+    return `${actualVotes[0][0]} with ${actualVotes[0][1]} votes (${(Number(actualVotes[0][1]) / numVotes * 100).toPrecision(3)}%)`;
 };
 
 export default function RoundPanel(props: Props) {
@@ -133,9 +137,14 @@ export default function RoundPanel(props: Props) {
                     <Grid size="auto" sx={{ display: 'inline-flex', alignItems: 'center' }}>
                         <img src={USER_VIOLET} height='16px' alt='jurors' style={{ marginRight: '5px' }} /><Typography>{props.votes.length} Jurors</Typography>
                     </Grid>
-                    <Grid size="auto" sx={{ display: 'inline-flex', alignItems: 'center' }}>
+                    <Grid size="auto" sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
                         <img src={BALANCE_VIOLET} height='16px' alt='jury' style={{ marginRight: '5px' }} />
                         <Typography>Jury Decision:&nbsp;</Typography><Typography>{juryDecison}</Typography>
+                        {props.isDynamicScriptLoading && (
+                            <Tooltip title="Loading ruling option titles…">
+                                <CircularProgress size={14} thickness={5} />
+                            </Tooltip>
+                        )}
                     </Grid>
                     <Grid size={12} sx={{ display: 'inline-flex', alignItems: 'center' }}>
                         <StackedBarChart data={chartData} />
@@ -147,7 +156,7 @@ export default function RoundPanel(props: Props) {
                     <Typography>Jurors weren't drawn yet</Typography>
                     :
                     props.votes.slice().sort((a, b) => a.address.id.localeCompare(b.address.id)).map((vote) => {
-                        return <VotePanel vote={vote} chainId={props.chainId} key={`VotePanel-${vote.id}`} metaEvidence={props.metaEvidence}/>
+                        return <VotePanel vote={vote} chainId={props.chainId} key={`VotePanel-${vote.id}`} metaEvidence={props.metaEvidence} isDynamicScriptLoading={props.isDynamicScriptLoading}/>
                     })
                 }
 

--- a/src/components/Case/VotePanel.tsx
+++ b/src/components/Case/VotePanel.tsx
@@ -14,6 +14,7 @@ interface Props {
   chainId: string
   vote: Vote
   metaEvidence?: MetaEvidence
+  isDynamicScriptLoading?: boolean
 }
 
 
@@ -58,7 +59,11 @@ export default function VotePanel(props: Props) {
           <Grid size={{ xs: 12, md: 3 }}>
             <JurorLink address={props.vote.address.id} chainId={props.chainId}/></Grid>
           <Grid size="grow">
-          <Tooltip title="If a * is in the text, means the most probably title for the vote when an error raise reading metaEvidence of the dispute."><Typography sx={justificationStyle}> {voteChoice}</Typography></Tooltip>
+          <Tooltip title={
+            props.isDynamicScriptLoading
+              ? "Loading ruling option titles from the contract…"
+              : "If a * is in the text, means the most probably title for the vote when an error raise reading metaEvidence of the dispute."
+          }><Typography sx={justificationStyle}> {voteChoice}</Typography></Tooltip>
           </Grid>
         </Grid>
       </AccordionSummary>

--- a/src/components/Case/VotingHistory.tsx
+++ b/src/components/Case/VotingHistory.tsx
@@ -12,6 +12,7 @@ interface Props {
     disputeId: BigNumberish
     chainId: string
     metaEvidence?: MetaEvidence
+    isDynamicScriptLoading?: boolean
     hiddenVotes: boolean
     period: string
 }
@@ -77,7 +78,7 @@ export default function VotingHistory(props: Props) {
                 props.rounds.map((round, index) => {
                     return (
                         <TabPanel value={value} index={index} key={`TabPanel-${index}`}>
-                            <RoundPanel disputeId={props.disputeId} votes={round.votes} chainId={props.chainId} roundId={round.id} metaEvidence={props.metaEvidence} hiddenVotes={props.hiddenVotes} period={props.period}/>
+                            <RoundPanel disputeId={props.disputeId} votes={round.votes} chainId={props.chainId} roundId={round.id} metaEvidence={props.metaEvidence} isDynamicScriptLoading={props.isDynamicScriptLoading} hiddenVotes={props.hiddenVotes} period={props.period}/>
                         </TabPanel>
                     )
                 })

--- a/src/hooks/useMetaEvidence.ts
+++ b/src/hooks/useMetaEvidence.ts
@@ -1,22 +1,70 @@
 import { useQuery } from "@tanstack/react-query";
-import { fetchMetaEvidence } from "../lib/fetchMetaEvidence";
+import {
+  fetchBaseMetaEvidence,
+  fetchDynamicScriptResult,
+  assembleMetaEvidence,
+} from "../lib/fetchMetaEvidence";
 import { MetaEvidence } from "../lib/types";
+
+export interface UseMetaEvidenceResult {
+  /** Base metaEvidence (title, description, etc.) — available quickly. */
+  metaEvidence: MetaEvidence | undefined;
+  /** True while the dynamic script sandbox is still running. */
+  isDynamicScriptLoading: boolean;
+  error: string | undefined;
+}
 
 export const useMetaEvidence = (
   chainId: string = "1",
   arbitrableId: string | undefined,
   disputeId: string
-): { metaEvidence: MetaEvidence | undefined; error: string | undefined } => {
-  const { data, error } = useQuery<MetaEvidence, Error>({
-    queryKey: ["metaEvidence", chainId, arbitrableId, disputeId],
+): UseMetaEvidenceResult => {
+  const enabled = !!chainId && !!arbitrableId && !!disputeId;
+
+  // Phase 1: fast — API + IPFS fetch only (~1-2s)
+  const baseQuery = useQuery({
+    queryKey: ["metaEvidenceBase", chainId, arbitrableId, disputeId],
     queryFn: () =>
-      fetchMetaEvidence({
+      fetchBaseMetaEvidence({
         chainId,
         arbitrableId: arbitrableId!,
         disputeId,
       }),
-    enabled: !!chainId && !!arbitrableId && !!disputeId,
+    enabled,
+    retry: 3,
+    staleTime: 5 * 60 * 1000,
   });
 
-  return { metaEvidence: data, error: error?.message };
+  // Phase 2: slow — dynamic script sandbox, no timeout, runs independently.
+  // Only starts once Phase 1 has succeeded and there IS a dynamic script.
+  const hasDynamicScript = !!baseQuery.data?.dynamicScriptUrl;
+
+  const dynamicQuery = useQuery({
+    queryKey: ["metaEvidenceDynamic", chainId, arbitrableId, disputeId],
+    queryFn: () => fetchDynamicScriptResult(baseQuery.data!),
+    enabled: enabled && !!baseQuery.data && hasDynamicScript,
+    retry: 1,
+    // Cache forever once resolved — re-running 800+ RPC calls on refocus is wasteful.
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+
+  // Build the MetaEvidence to expose to consumers:
+  // - While base is loading: undefined
+  // - Base loaded, no dynamic script: assemble immediately with interfaceValid=true
+  // - Base loaded, dynamic running: assemble from base JSON (titles will be missing/generic)
+  // - Dynamic done: assemble from merged JSON
+  let metaEvidence: MetaEvidence | undefined;
+  const isDynamicScriptLoading =
+    hasDynamicScript && !dynamicQuery.data && !dynamicQuery.isError;
+
+  if (baseQuery.data) {
+    const json = dynamicQuery.data ?? baseQuery.data.metaEvidenceJSON;
+    const interfaceValid = !hasDynamicScript || !!dynamicQuery.data;
+    metaEvidence = assembleMetaEvidence(json, interfaceValid);
+  }
+
+  const error = baseQuery.error?.message;
+
+  return { metaEvidence, isDynamicScriptLoading, error };
 };

--- a/src/lib/dynamicScriptSandbox.ts
+++ b/src/lib/dynamicScriptSandbox.ts
@@ -50,13 +50,7 @@ export default function executeDynamicScript(
       }
     };
 
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
     const cleanup = () => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-        timeoutId = null;
-      }
       window.removeEventListener("message", messageHandler);
       if (blobUrl) {
         URL.revokeObjectURL(blobUrl);
@@ -69,10 +63,9 @@ export default function executeDynamicScript(
     window.addEventListener("message", messageHandler);
     document.body.appendChild(iframe);
 
-    timeoutId = setTimeout(() => {
-      cleanup();
-      reject(new Error("Dynamic script sandbox timeout after 30s"));
-    }, 30000);
+    // No timeout — cross-chain Reality.eth scripts make 800+ sequential RPC calls
+    // and can take several minutes. The caller (fetchDynamicScriptResult / React Query)
+    // is responsible for any cancellation policy. We just wait for completion.
 
     // Build the iframe content as an HTML document
     // Structure:

--- a/src/lib/fetchMetaEvidence.ts
+++ b/src/lib/fetchMetaEvidence.ts
@@ -8,43 +8,22 @@ import {
 import { MetaEvidence, MetaEvidenceJson } from './types';
 
 /**
- * Fallback MetaEvidence returned when dynamic script execution fails after 120s retry loop.
+ * Phase 1 result: base metaEvidence fetched from API + IPFS.
+ * Does NOT include dynamic script results yet.
  */
-const FALLBACK_META_EVIDENCE: MetaEvidenceJson = {
-  fileURI: '',
-  fileHash: '',
-  fileTypeExtension: '',
-  category: '',
-  title: 'Invalid or tampered case data, refuse to arbitrate.',
-  description:
-    'The data for this case is not formatted correctly or has been tampered since the time of its submission. Please refresh the page and refuse to arbitrate if the problem persists.',
-  aliases: {},
-  question: '',
-  rulingOptions: {
-    type: 'single-select',
-    precision: 0,
-    titles: [],
-    descriptions: [],
-  },
-  dynamicScriptURI: '',
-  dynamicScriptHash: '',
-};
+export interface BaseMetaEvidence {
+  metaEvidenceJSON: MetaEvidenceJson;
+  sandboxConfig: SandboxConfig;
+  scriptParameters: Record<string, string> | null;
+  dynamicScriptUrl: string | null;
+}
 
 /**
- * Fetch metaEvidence for a dispute via Kleros public API + IPFS + dynamic script sandbox.
- * Implements 120s retry loop for the entire fetch + script execution pipeline.
- *
- * Steps:
- * 1. Resolve sandbox configuration based on whitelist
- * 2. Retry loop (120s, 5s intervals):
- *    a. Call Kleros API to get metaEvidence IPFS URI
- *    b. Fetch metaEvidence JSON from IPFS gateway
- *    c. If dynamicScriptURI exists, fetch script and execute in sandbox (with RPC redirect)
- *    d. Merge script result into metaEvidenceJSON
- * 3. On success: return typed MetaEvidence
- * 4. On timeout: return fallback MetaEvidence with interfaceValid=false
+ * Phase 1: Fetch metaEvidence JSON from Kleros API + IPFS.
+ * Fast (~1-2s). Does not execute any dynamic script.
+ * Throws on failure so TanStack Query can retry.
  */
-export async function fetchMetaEvidence({
+export async function fetchBaseMetaEvidence({
   chainId,
   arbitrableId,
   disputeId,
@@ -52,8 +31,7 @@ export async function fetchMetaEvidence({
   chainId: string;
   arbitrableId: string;
   disputeId: string;
-}): Promise<MetaEvidence> {
-  // Resolve sandbox configuration based on arbitrable whitelist
+}): Promise<BaseMetaEvidence> {
   const chainIdNum = parseInt(chainId, 10);
   const isWhitelisted =
     arbitrableWhitelist[chainIdNum]?.includes(arbitrableId.toLowerCase()) ??
@@ -66,147 +44,114 @@ export async function fetchMetaEvidence({
     rpcUrl: getRPCURL(chainId),
   };
 
-  const maxRetryTime = 120000; // 120 seconds
-  const retryInterval = 5000; // 5 seconds
-  const startTime = Date.now();
+  // Step 1: Get metaEvidence URI from Kleros API
+  const apiUrl = new URL(import.meta.env.VITE_KLEROS_API_URL);
+  apiUrl.searchParams.set('chainId', chainId);
+  apiUrl.searchParams.set('disputeId', disputeId);
 
-  while (Date.now() - startTime < maxRetryTime) {
-    try {
-      // Step 1: Get metaEvidence URI from Kleros API
-      const apiUrl = new URL(import.meta.env.VITE_KLEROS_API_URL);
-      apiUrl.searchParams.set('chainId', chainId);
-      apiUrl.searchParams.set('disputeId', disputeId);
-
-      const apiResponse = await fetch(apiUrl.toString());
-      if (!apiResponse.ok) {
-        throw new Error(`API error: ${apiResponse.status}`);
-      }
-
-      const apiData = await apiResponse.json();
-      const metaEvidenceUri = apiData.metaEvidenceUri;
-
-      if (!metaEvidenceUri) {
-        throw new Error('No metaEvidenceUri in API response');
-      }
-
-      // Step 2: Fetch metaEvidence JSON from IPFS
-      const metaEvidenceUrl = `https://cdn.kleros.link${metaEvidenceUri}`;
-      const metaEvidenceResponse = await fetch(metaEvidenceUrl);
-      if (!metaEvidenceResponse.ok) {
-        throw new Error(
-          `Failed to fetch metaEvidence JSON: ${metaEvidenceResponse.status}`,
-        );
-      }
-
-      let metaEvidenceJSON: MetaEvidenceJson =
-        await metaEvidenceResponse.json();
-      let interfaceValid = true;
-
-      // Step 3 & 4: Handle dynamic script if present
-      if (metaEvidenceJSON.dynamicScriptURI) {
-        try {
-          const dynamicScriptUrl = `https://cdn.kleros.link${metaEvidenceJSON.dynamicScriptURI}`;
-          const scriptResponse = await fetch(dynamicScriptUrl);
-          if (!scriptResponse.ok) {
-            throw new Error(
-              `Failed to fetch dynamic script: ${scriptResponse.status}`,
-            );
-          }
-
-          const scriptText = await scriptResponse.text();
-
-          // Prepare script parameters
-          const KL =
-            chainId === '100' ? GNOSIS_KLEROSLIQUID : MAINNET_KLEROSLIQUID;
-          // Some arbitrables live on a different chain than the arbitrator (e.g. Reality.eth on Gnosis).
-          // Read arbitrableChainID from the metaEvidence JSON if present; fall back to arbitrator chain.
-          const arbitratorChainID = metaEvidenceJSON.arbitratorChainID ?? chainId;
-          const arbitrableChainID = metaEvidenceJSON.arbitrableChainID ?? arbitratorChainID;
-          const scriptParameters = {
-            disputeID: disputeId,
-            arbitrableContractAddress: arbitrableId,
-            arbitratorContractAddress: KL,
-            arbitratorChainID: arbitratorChainID,
-            arbitrableChainID: arbitrableChainID,
-            arbitratorJsonRpcUrl: getRPCURL(arbitratorChainID),
-            arbitrableJsonRpcUrl: getRPCURL(arbitrableChainID),
-          };
-
-          // Execute script in sandbox — use arbitrable chain RPC for the redirect patch
-          // so any hardcoded RPC URLs inside the script get redirected to the right chain.
-          const scriptSandboxConfig = {
-            ...sandboxConfig,
-            rpcUrl: getRPCURL(arbitrableChainID),
-          };
-
-          const scriptResult = await executeDynamicScript(
-            scriptText,
-            scriptParameters,
-            scriptSandboxConfig,
-          );
-
-          // Merge result into metaEvidenceJSON
-          if (scriptResult && typeof scriptResult === 'object') {
-            metaEvidenceJSON = {
-              ...metaEvidenceJSON,
-              ...scriptResult,
-            };
-          }
-        } catch (scriptError) {
-          // Log warning but don't fail — return base metaEvidence without dynamic result
-          console.warn('Dynamic script execution failed:', scriptError);
-          interfaceValid = false;
-        }
-      }
-
-      // Step 5: Return typed MetaEvidence on success
-      return {
-        metaEvidenceValid: true,
-        fileValid: true,
-        interfaceValid,
-        metaEvidenceJSON,
-        submittedAt: Date.now(),
-        blockNumber: 0,
-        transactionHash: '',
-      };
-    } catch (error) {
-      // Log the error and retry after delay
-      console.warn(
-        `Attempt to fetch metaEvidence failed (${Math.floor((Date.now() - startTime) / 1000)}s elapsed):`,
-        error instanceof Error ? error.message : String(error),
-      );
-
-      // Check if we have time for another retry
-      const timeElapsed = Date.now() - startTime;
-      const timeRemaining = maxRetryTime - timeElapsed;
-
-      if (timeRemaining <= 0) {
-        // Timeout reached, return fallback
-        console.error(
-          `Failed to fetch metaEvidence after 120s retry loop. Returning fallback MetaEvidence.`,
-        );
-        return {
-          metaEvidenceValid: true,
-          fileValid: true,
-          interfaceValid: false,
-          metaEvidenceJSON: FALLBACK_META_EVIDENCE,
-          submittedAt: Date.now(),
-          blockNumber: 0,
-          transactionHash: '',
-        };
-      }
-
-      // Wait before retrying
-      await new Promise((resolve) => setTimeout(resolve, retryInterval));
-    }
+  const apiResponse = await fetch(apiUrl.toString());
+  if (!apiResponse.ok) {
+    throw new Error(`API error: ${apiResponse.status}`);
   }
 
-  // Fallback (should not reach here, but just in case)
+  const apiData = await apiResponse.json();
+  const metaEvidenceUri = apiData.metaEvidenceUri;
+
+  if (!metaEvidenceUri) {
+    throw new Error('No metaEvidenceUri in API response');
+  }
+
+  // Step 2: Fetch metaEvidence JSON from IPFS
+  const metaEvidenceUrl = `https://cdn.kleros.link${metaEvidenceUri}`;
+  let metaEvidenceResponse = await fetch(metaEvidenceUrl);
+  if (!metaEvidenceResponse.ok && metaEvidenceUri.endsWith('.')) {
+    const fallbackUrl = `https://cdn.kleros.link${metaEvidenceUri}json`;
+    metaEvidenceResponse = await fetch(fallbackUrl);
+  }
+  if (!metaEvidenceResponse.ok) {
+    throw new Error(
+      `Failed to fetch metaEvidence JSON: ${metaEvidenceResponse.status}`,
+    );
+  }
+
+  const metaEvidenceJSON: MetaEvidenceJson = await metaEvidenceResponse.json();
+
+  // Step 3: Prepare dynamic script params if present (but don't execute yet)
+  let scriptParameters: Record<string, string> | null = null;
+  let dynamicScriptUrl: string | null = null;
+
+  if (metaEvidenceJSON.dynamicScriptURI) {
+    const KL =
+      chainId === '100' ? GNOSIS_KLEROSLIQUID : MAINNET_KLEROSLIQUID;
+    const arbitratorChainID = metaEvidenceJSON.arbitratorChainID ?? chainId;
+    const arbitrableChainID = metaEvidenceJSON.arbitrableChainID ?? arbitratorChainID;
+
+    scriptParameters = {
+      disputeID: disputeId,
+      arbitrableContractAddress: arbitrableId,
+      arbitratorContractAddress: KL,
+      arbitratorChainID,
+      arbitrableChainID,
+      arbitratorJsonRpcUrl: getRPCURL(arbitratorChainID),
+      arbitrableJsonRpcUrl: getRPCURL(arbitrableChainID),
+    };
+
+    dynamicScriptUrl = `https://cdn.kleros.link${metaEvidenceJSON.dynamicScriptURI}`;
+  }
+
+  return { metaEvidenceJSON, sandboxConfig, scriptParameters, dynamicScriptUrl };
+}
+
+/**
+ * Phase 2: Execute the dynamic script in the sandbox.
+ * Can take minutes for cross-chain Reality.eth scripts (~800+ RPC calls).
+ * No timeout — runs until completion or error.
+ * Returns the merged metaEvidenceJSON with rulingOptions.titles populated.
+ */
+export async function fetchDynamicScriptResult(
+  base: BaseMetaEvidence,
+): Promise<MetaEvidenceJson> {
+  const { metaEvidenceJSON, sandboxConfig, scriptParameters, dynamicScriptUrl } = base;
+
+  if (!dynamicScriptUrl || !scriptParameters) {
+    return metaEvidenceJSON;
+  }
+
+  const scriptResponse = await fetch(dynamicScriptUrl);
+  if (!scriptResponse.ok) {
+    throw new Error(`Failed to fetch dynamic script: ${scriptResponse.status}`);
+  }
+  const scriptText = await scriptResponse.text();
+
+  const scriptSandboxConfig: SandboxConfig = {
+    ...sandboxConfig,
+    rpcUrl: getRPCURL(scriptParameters.arbitrableChainID),
+  };
+
+  const scriptResult = await executeDynamicScript(
+    scriptText,
+    scriptParameters,
+    scriptSandboxConfig,
+  );
+
+  if (scriptResult && typeof scriptResult === 'object') {
+    return { ...metaEvidenceJSON, ...scriptResult };
+  }
+  return metaEvidenceJSON;
+}
+
+/**
+ * Assemble a MetaEvidence from a base fetch + optional dynamic result.
+ */
+export function assembleMetaEvidence(
+  metaEvidenceJSON: MetaEvidenceJson,
+  interfaceValid: boolean,
+): MetaEvidence {
   return {
     metaEvidenceValid: true,
     fileValid: true,
-    interfaceValid: false,
-    metaEvidenceJSON: FALLBACK_META_EVIDENCE,
+    interfaceValid,
+    metaEvidenceJSON,
     submittedAt: Date.now(),
     blockNumber: 0,
     transactionHash: '',

--- a/src/pages/Dispute.tsx
+++ b/src/pages/Dispute.tsx
@@ -19,7 +19,7 @@ export default function Dispute() {
   const chainId = match ? match[1] : null
 
   const { data } = useDispute(chainId!, id!);
-  const { metaEvidence, error } = useMetaEvidence(
+  const { metaEvidence, isDynamicScriptLoading, error } = useMetaEvidence(
     chainId!,
     data ? data.arbitrable.id : undefined,
     id!
@@ -91,6 +91,7 @@ export default function Dispute() {
           roundNum={data!.rounds.length}
           startTimestamp={data!.startTime}
           metaEvidence={metaEvidence}
+          isDynamicScriptLoading={isDynamicScriptLoading}
         />
       ) : (
         <Skeleton width={"100%"} height="200px" />
@@ -103,6 +104,7 @@ export default function Dispute() {
           disputeId={data.id}
           chainId={chainId!}
           metaEvidence={metaEvidence}
+          isDynamicScriptLoading={isDynamicScriptLoading}
           hiddenVotes={!!(data.subcourtID as Court).hiddenVotes}
           period={data.period}
         />


### PR DESCRIPTION
## Summary

- Split `fetchMetaEvidence` into two independent React Query phases: **base** (fast, ~1-2s) and **dynamic** (sandbox, no timeout, runs in background)
- Remove the 120s sandbox timeout — cross-chain Reality.eth scripts (e.g. case 1661) make 800+ sequential RPC calls and need several minutes to complete
- Show a spinner next to Jury Decision while the dynamic script runs; ruling titles update in place once resolved (`staleTime: Infinity` avoids re-running on window refocus)
- Fix `getJuryDecision` to exclude Pending/Committed from winner calculation — only actual vote options can be the winning ruling

## Root cause

Court.kleros.io (via archon) has no timeout on the sandbox. Our 120s timeout caused the sandbox iframe to be destroyed mid-execution, aborting all in-flight RPC requests and showing the error fallback. The script itself works fine — it just takes a long time.

## Changes

| File | Change |
|------|--------|
| `src/lib/fetchMetaEvidence.ts` | Split into `fetchBaseMetaEvidence`, `fetchDynamicScriptResult`, `assembleMetaEvidence` |
| `src/lib/dynamicScriptSandbox.ts` | Removed 120s timeout |
| `src/hooks/useMetaEvidence.ts` | Two queries: base (retry 3) + dynamic (staleTime: Infinity) |
| `src/pages/Dispute.tsx` | Pass `isDynamicScriptLoading` down |
| `src/components/Case/VotingHistory.tsx` | Propagate `isDynamicScriptLoading` |
| `src/components/Case/RoundPanel.tsx` | CircularProgress spinner + fix `getJuryDecision` |
| `src/components/Case/VotePanel.tsx` | Updated tooltip when titles loading |
| `src/components/Case/CaseInfo.tsx` | Accept `isDynamicScriptLoading` prop |

## Test

- Case 1661 (cross-chain Reality.eth): loads in ~2s with base info, spinner visible, titles update when script finishes
- Case 554 (regular evidence, no dynamic script): unaffected, loads normally
- Jury Decision no longer shows "Pending" as winner when real votes exist