### PR TITLE
refactor(curate): migrate from legacy-curate to HyperIndex (Envio) indexer

### DIFF
--- a/env.example
+++ b/env.example
@@ -5,3 +5,6 @@ VITE_WEB3_POLYGON_PROVIDER_URL=https://polygon-pokt.nodies.app
 VITE_GRAPHQL_TOKEN='123456abcdef123456abcdef123456ab'
 VITE_SUBGRAPH_MAINNET=https://gateway.thegraph.com/api/subgraphs/id/ECENsJRfqi6Mwj6kF9diShPzFKkgyyo79aSCkSwAShHL
 VITE_SUBGRAPH_GNOSIS=https://gateway.thegraph.com/api/subgraphs/id/Ck26N16xgimEuuuNSJqYVWBKcWSwPmkk36BWZGtfx1ox
+
+# HyperIndex (Envio) — unifica mainnet + gnosis en un solo endpoint
+VITE_CURATE_SUBGRAPH=https://indexer.hyperindex.xyz/[api-key]/v1/graphql

--- a/src/graphql/subgraph.ts
+++ b/src/graphql/subgraph.ts
@@ -394,12 +394,24 @@ export const DONOR_FIELDS = `
 export interface LItem {
     itemID: string,
     keywords: string,
+    key0: string,     // name / label
+    key1: string,     // arbitrable address
+    key2: string,     // url / description (optional)
+    registryAddress: string,
+    chainId: number,
+    status: string,
   }
 
 
 export const LITEM_FIELDS = `
   fragment LItemFields on LItem {
     itemID
+    key0
+    key1
+    key2
     keywords
+    registryAddress
+    chainId
+    status
 }
 `

--- a/src/hooks/useArbitrableName.ts
+++ b/src/hooks/useArbitrableName.ts
@@ -1,56 +1,65 @@
-import { LITEM_FIELDS, LItem } from "../graphql/subgraph";
+import { LItem } from "../graphql/subgraph";
 import { useQuery } from "@tanstack/react-query";
-import {
-  apolloCurateGnosisQuery,
-  apolloCurateMainnetQuery,
-} from "../lib/apolloClient";
-import { QueryVariables, buildQuery } from "../lib/SubgraphQueryBuilder";
+import { curateQuery } from "../lib/apolloClient";
 import { shortenIfAddress } from "../lib/utils";
 import {
   ADDRESS_TAG_REGISTRY_GNOSIS,
   ADDRESS_TAG_REGISTRY_MAINNET,
 } from "../lib/helpers";
 
-const query = `
-    ${LITEM_FIELDS}
-    query ArbitrableNameQuery(#params#) {
-      litems(where: {#where#}, first: 1000, orderBy: latestRequestResolutionTime, orderDirection:desc) {
-        ...LItemFields
-      }
-    }
+const LITEM_NAME_FIELDS = `
+  fragment LItemNameFields on LItem {
+    key0
+    key1
+  }
 `;
 
+const fetchNameByAddress = async (
+  arbitrableId: string,
+): Promise<string> => {
+  const address = arbitrableId.toLowerCase();
+  let name: string = shortenIfAddress(address);
+
+  // Query both registries simultaneously for the given address
+  const query = `
+    ${LITEM_NAME_FIELDS}
+    query ArbitrableNameQuery($registryGnosis: String!, $registryMainnet: String!, $address: String!) {
+      gnosis: LItem(
+        where: {registryAddress: {_eq: $registryGnosis}, chainId: {_eq: 100}, key1: {_eq: $address}}
+        limit: 1
+      ) { ...LItemNameFields }
+      mainnet: LItem(
+        where: {registryAddress: {_eq: $registryMainnet}, chainId: {_eq: 1}, key1: {_eq: $address}}
+        limit: 1
+      ) { ...LItemNameFields }
+    }
+  `;
+
+  const data = await curateQuery<{
+    gnosis: LItem[];
+    mainnet: LItem[];
+  }>(query, {
+    registryGnosis: ADDRESS_TAG_REGISTRY_GNOSIS.toLowerCase(),
+    registryMainnet: ADDRESS_TAG_REGISTRY_MAINNET.toLowerCase(),
+    address,
+  });
+
+  const gnosisItems = data?.gnosis ?? [];
+  const mainnetItems = data?.mainnet ?? [];
+
+  if (gnosisItems.length > 0) {
+    name = gnosisItems[0].key0;
+  } else if (mainnetItems.length > 0) {
+    name = mainnetItems[0].key0;
+  }
+
+  return name;
+};
+
 export const useArbitrableName = (arbitrableId: string) => {
-  return useQuery<string, Error>({ queryKey: ["useArbitrableName"], queryFn: async () => {
-    const variables: QueryVariables = {};
-    let name: string = shortenIfAddress(arbitrableId);
-
-    if (arbitrableId) {
-      variables["keywords_contains_nocase"] = arbitrableId.toLowerCase();
-      variables["registryAddress"] = ADDRESS_TAG_REGISTRY_GNOSIS;
-    }
-
-    const response = await apolloCurateGnosisQuery<{
-      litems: LItem[];
-    }>(buildQuery(query, variables), variables);
-
-    if (!response || !response.data) throw new Error("No response from TheGraph");
-    if (response.data!.litems.length !== 0) {
-      name = response.data!.litems[0].keywords.split(" | ")[1];
-    } else {
-      // search in mainnet list
-      variables["registryAddress"] = ADDRESS_TAG_REGISTRY_MAINNET;
-
-      const response2 = await apolloCurateMainnetQuery<{
-        litems: LItem[];
-      }>(buildQuery(query, variables), variables);
-
-      if (!response2) throw new Error("No response from TheGraph");
-
-      if (response2.data!.litems.length !== 0) {
-        name = response2.data!.litems[0].keywords.split(" | ")[1];
-      }
-    }
-    return name;
-  }});
+  return useQuery<string, Error>({
+    queryKey: ["useArbitrableName", arbitrableId],
+    queryFn: () => fetchNameByAddress(arbitrableId),
+    enabled: !!arbitrableId,
+  });
 };

--- a/src/hooks/useArbitrablesNames.ts
+++ b/src/hooks/useArbitrablesNames.ts
@@ -1,54 +1,60 @@
-import { LITEM_FIELDS, LItem } from "../graphql/subgraph";
-import { useQuery } from "@tanstack/react-query";
-import { apolloCurateGnosisQuery, apolloCurateMainnetQuery } from "../lib/apolloClient";
-import { QueryVariables, buildQuery } from "../lib/SubgraphQueryBuilder";
-import { ADDRESS_TAG_REGISTRY_GNOSIS, ADDRESS_TAG_REGISTRY_MAINNET } from "../lib/helpers";
+import { useQuery } from '@tanstack/react-query';
+import { LITEM_FIELDS, LItem } from '../graphql/subgraph';
+import { curateQuery } from '../lib/apolloClient';
+import {
+  ADDRESS_TAG_REGISTRY_GNOSIS,
+  ADDRESS_TAG_REGISTRY_MAINNET,
+} from '../lib/helpers';
 
-const query = `
-    ${LITEM_FIELDS}
-    query ArbitrableNamesQuery(#params#) {
-      litems(where: {#where#}, first: 1000, orderBy: latestRequestResolutionTime, orderDirection:asc, skip:$skip) {
-          ...LItemFields
-      }
+const PAGE_SIZE = 1000;
+
+const buildQuery = (chainId: number) => `
+  ${LITEM_FIELDS}
+  query ArbitrablesNamesQuery($registryAddress: String!, $offset: Int!) {
+    items: LItem(
+      where: {registryAddress: {_eq: $registryAddress}, chainId: {_eq: ${chainId}}}
+      limit: ${PAGE_SIZE}
+      offset: $offset
+      order_by: {latestRequestResolutionTime: asc}
+    ) {
+      ...LItemFields
     }
+  }
 `;
+
+const fetchRegistryItems = async (
+  registryAddress: string,
+  chainId: number,
+): Promise<LItem[]> => {
+  const allItems: LItem[] = [];
+  let offset = 0;
+  let hasMore = true;
+
+  while (hasMore) {
+    const query = buildQuery(chainId);
+    const data = await curateQuery<{ items: LItem[] }>(query, {
+      registryAddress: registryAddress.toLowerCase(),
+      offset,
+    });
+
+    const items = data?.items ?? [];
+    allItems.push(...items);
+    hasMore = items.length === PAGE_SIZE;
+    offset += PAGE_SIZE;
+  }
+
+  return allItems;
+};
 
 export const useArbitrablesNames = () => {
   return useQuery<LItem[], Error>({
-    queryKey: ["useArbitrablesNames"],
+    queryKey: ['useArbitrablesNames'],
     queryFn: async () => {
-      let litems: LItem[] = [];
-      const variables: QueryVariables = {};
-      // search in gnosis registry
-      variables['registryAddress'] = ADDRESS_TAG_REGISTRY_GNOSIS; // gnosis registry
-      let iterate: boolean = true
-      while (iterate) {
-        variables["skip"] = litems.length;
-
-        const response = await apolloCurateGnosisQuery<{
-          litems: LItem[];
-        }>(buildQuery(query, variables), variables);
-
-        if (!response || !response.data) throw new Error("No response from TheGraph");
-        litems = litems.concat(response.data!.litems);
-        iterate = response.data!.litems.length === 1000;
-      }
-      const skipOffset = litems.length;
-      iterate = true;
-      // search in mainnet registry
-      variables['registryAddress'] = ADDRESS_TAG_REGISTRY_MAINNET; // mainnet registry
-      while (iterate) {
-        variables["skip"] = litems.length - skipOffset;
-        
-        const response2 = await apolloCurateMainnetQuery<{
-          litems: LItem[];
-        }>(buildQuery(query, variables), variables);
-
-        if (!response2) throw new Error("No response from TheGraph");
-        litems = litems.concat(response2.data!.litems);
-        iterate = response2.data!.litems.length === 1000;
-      }
-      return litems;
-    }
+      const [gnosisItems, mainnetItems] = await Promise.all([
+        fetchRegistryItems(ADDRESS_TAG_REGISTRY_GNOSIS, 100),
+        fetchRegistryItems(ADDRESS_TAG_REGISTRY_MAINNET, 1),
+      ]);
+      return [...gnosisItems, ...mainnetItems];
+    },
   });
 };

--- a/src/lib/apolloClient.ts
+++ b/src/lib/apolloClient.ts
@@ -28,22 +28,6 @@ const gnosisClient = new ApolloClient({
   cache: new InMemoryCache(),
 });
 
-const curateGnosisClient = new ApolloClient({
-  link: new HttpLink({
-    uri: import.meta.env.VITE_CURATE_SUBGRAPH_GNOSIS ||
-      'https://api.studio.thegraph.com/query/61738/legacy-curate-xdai/version/latest',
-  }),
-  cache: new InMemoryCache(),
-});
-
-const curateMainnetClient = new ApolloClient({
-  link: new HttpLink({
-    uri: import.meta.env.VITE_CURATE_SUBGRAPH_MAINNET ||
-      'https://api.studio.thegraph.com/query/61738/legacy-curate-mainnet/version/latest',
-  }),
-  cache: new InMemoryCache(),
-});
-
 const sepoliaClient = new ApolloClient({
   link: new HttpLink({
     uri: import.meta.env.VITE_SUBGRAPH_SEPOLIA ||
@@ -65,20 +49,6 @@ const apolloClientQuery = async <T>(
   return apolloQuery<T>(mainnetClient, queryString, variables);
 };
 
-const apolloCurateGnosisQuery = async <T>(
-  queryString: string,
-  variables: Record<string, any> = {},
-) => {
-  return apolloQuery<T>(curateGnosisClient, queryString, variables);
-};
-
-const apolloCurateMainnetQuery = async <T>(
-  queryString: string,
-  variables: Record<string, any> = {},
-) => {
-  return apolloQuery<T>(curateMainnetClient, queryString, variables);
-};
-
 const apolloQuery = async <T>(
   client: ApolloClient,
   queryString: string,
@@ -94,4 +64,38 @@ const apolloQuery = async <T>(
   }
 };
 
-export { apolloClientQuery, apolloCurateGnosisQuery, apolloCurateMainnetQuery };
+/**
+ * Query the HyperIndex (Envio) curate subgraph.
+ * Single endpoint for both mainnet (chainId=1) and gnosis (chainId=100).
+ * Uses direct fetch instead of Apollo Client — no query builder needed.
+ */
+const CURATE_ENDPOINT = import.meta.env.VITE_CURATE_SUBGRAPH;
+
+interface CurateVariables {
+  [key: string]: any;
+}
+
+const curateQuery = async <T>(
+  query: string,
+  variables: CurateVariables = {},
+): Promise<T> => {
+  if (!CURATE_ENDPOINT) {
+    console.error('VITE_CURATE_SUBGRAPH is not set');
+    return {} as T;
+  }
+
+  try {
+    const response = await fetch(CURATE_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query, variables }),
+    });
+    const json = await response.json();
+    return json.data as T;
+  } catch (err) {
+    console.error('curate subgraph error: ', err);
+    return {} as T;
+  }
+};
+
+export { apolloClientQuery, curateQuery };

--- a/src/pages/Arbitrables.tsx
+++ b/src/pages/Arbitrables.tsx
@@ -13,8 +13,8 @@ import { shortenIfAddress } from "../lib/utils";
 
 
 function getArbitrableName(arbitrable: string, arbitrableNames: LItem[]): string {
-  const foundItem = arbitrableNames.find((item) => item.keywords.split(' | ')[2]?.toLowerCase() === arbitrable.toLowerCase());
-  return foundItem ? foundItem.keywords.split(' | ')[1] : shortenIfAddress(arbitrable);
+  const foundItem = arbitrableNames.find((item) => item.key1?.toLowerCase() === arbitrable.toLowerCase());
+  return foundItem ? foundItem.key0 : shortenIfAddress(arbitrable);
 }
 
 


### PR DESCRIPTION
## Summary
- Migrated from two separate Apollo Client curate subgraph instances (per chain) to a single `fetch`-based `curateQuery` function pointing to the new HyperIndex endpoint
- The Address Tag registries are Light TCRs (LItem/LRegistry) on the new indexer
- Removed `apolloCurateGnosisQuery` and `apolloCurateMainnetQuery` exports

## Changes
| File | Change |
|------|--------|
| `src/lib/apolloClient.ts` | Removed curate Apollo clients; added `curateQuery` using `fetch()` |
| `src/graphql/subgraph.ts` | Expanded LItem with key0-key2, registryAddress, chainId, status |
| `src/hooks/useArbitrablesNames.ts` | Migrated to HyperIndex query, offset pagination, Promise.all |
| `src/hooks/useArbitrableName.ts` | Single query for both chains, search by `key1: {_eq}` |
| `src/pages/Arbitrables.tsx` | getArbitrableName uses key0/key1 instead of parsing keywords |
| `env.example` | Added VITE_CURATE_SUBGRAPH |

## Schema Changes
| Old | New |
|-----|-----|
| `litems(... first: 1000, skip: $skip)` | `LItem(... limit: 1000, offset: $offset)` |
| `keywords_contains_nocase: "0x..."` | `key1: {_eq: "0x..."}` |
| `keywords.split(' | ')[1]` | `key0` (name) |
| Two Apollo clients (gnosis + mainnet) | Single `fetch()` to HyperIndex |
| Separate endpoint per chain | Single endpoint with `chainId` filter |

## Test Plan
- [x] Build passes: `npx tsc --noEmit` + `npx vite build`
- [x] Verify VITE_CURATE_SUBGRAPH is set in deployment environment
- [x] Test name resolution on Arbitrables page
- [x] Test ArbitrableLink component on disputed cases