### PR TITLE
fix(pagination): restore DataGrid pagination across all tables

### DIFF
--- a/src/components/LatestDisputes.tsx
+++ b/src/components/LatestDisputes.tsx
@@ -1,7 +1,7 @@
 import { Box, Typography } from '@mui/material';
 import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import { BigNumberish } from '../lib/types';
-import React from 'react'
+import React, { useState } from 'react'
 import { Court, Dispute } from '../graphql/subgraph';
 import { useDisputes } from '../hooks/useDisputes';
 import { formatDate, getPeriodNumber } from '../lib/helpers';
@@ -18,6 +18,7 @@ interface Props {
 }
 
 export default function LatestDisputes(props: Props) {
+    const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
     const { data: disputes, isLoading: disputes_loading } = useDisputes({chainId: props.chainId, subcourtID: props.courtId});
 
      const dispute_columns: GridColDef<Dispute>[] = [
@@ -70,7 +71,8 @@ export default function LatestDisputes(props: Props) {
                 rows={disputes ? disputes! : []}
                 columns={props.courtRendering ? dispute_columns_court : dispute_columns}
                 loading={disputes_loading}
-                paginationModel={{ page: 0, pageSize: 10 }}
+                paginationModel={paginationModel}
+                onPaginationModelChange={(model) => setPaginationModel(model)}
                 disableRowSelectionOnClick
                 autoHeight={true}
                 hideFooter={props.hideFooter === undefined? true: props.hideFooter}

--- a/src/components/LatestStakes.tsx
+++ b/src/components/LatestStakes.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Box, Typography } from "@mui/material";
 import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import { shortenAddress } from "../lib/utils";
@@ -18,6 +18,7 @@ interface Props {
 }
 
 export default function LatestStakes(props: Props) {
+  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
   const { data: stakes, isLoading: stakes_loading } = useStakes({
     chainId: props.chainId,
     subcourtID: props.courtId,
@@ -143,7 +144,8 @@ export default function LatestStakes(props: Props) {
               : columns_stakes
           }
           loading={stakes_loading}
-          paginationModel={{ page: 0, pageSize: 10 }}
+          paginationModel={paginationModel}
+          onPaginationModelChange={(model) => setPaginationModel(model)}
           disableRowSelectionOnClick
           autoHeight={true}
           hideFooter={props.hideFooter === undefined ? true : props.hideFooter}

--- a/src/components/Profile/CreatedCases.tsx
+++ b/src/components/Profile/CreatedCases.tsx
@@ -1,7 +1,7 @@
 import { Box, Skeleton, Typography } from "@mui/material";
 import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import { BigNumberish } from "../../lib/types";
-import React from "react";
+import React, { useState } from "react";
 import { formatDate, getBlockExplorer } from "../../lib/helpers";
 import CourtLink from "../CourtLink";
 import { Link } from "@mui/material";
@@ -16,6 +16,7 @@ interface Props {
 }
 
 export default function CreatedCases(props: Props) {
+  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
   const blockExplorer = getBlockExplorer(props.chainId);
 
   const dispute_columns: GridColDef<Dispute>[] = [
@@ -82,7 +83,8 @@ export default function CreatedCases(props: Props) {
           rows={props.cases ? props.cases! : []}
           columns={dispute_columns}
           loading={props.isLoading}
-          paginationModel={{ page: 0, pageSize: 10 }}
+          paginationModel={paginationModel}
+          onPaginationModelChange={(model) => setPaginationModel(model)}
           disableRowSelectionOnClick
           autoHeight={true}
           hideFooter={false}

--- a/src/components/Profile/VotedCases.tsx
+++ b/src/components/Profile/VotedCases.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export default function VotedCases(props: Props) {
-  const [pageSize, setPageSize] = useState<number>(10);
+  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
   const columns: GridColDef<Vote>[] = [
     {
       field: "dispute",
@@ -111,9 +111,9 @@ export default function VotedCases(props: Props) {
            sx={{ marginTop: "30px" }}
            rows={props.votes ? props.votes! : []}
            columns={columns}
-           paginationModel={{ page: 0, pageSize }}
-           loading={props.isLoading}
-           onPaginationModelChange={(model) => setPageSize(model.pageSize)}
+            paginationModel={paginationModel}
+            loading={props.isLoading}
+            onPaginationModelChange={(model) => setPaginationModel(model)}
            pageSizeOptions={[10, 50, 100]}
             disableRowSelectionOnClick
            autoHeight={true}

--- a/src/pages/Arbitrable.tsx
+++ b/src/pages/Arbitrable.tsx
@@ -25,7 +25,7 @@ export default function Arbitrable() {
   const { data: disputes, isLoading: isLoadingDisputes } = useDisputes({ chainId: chainId!, arbitrableID: id! });
   const { data: arbitrableName } = useArbitrableName(id!);
   const blockExplorer = getBlockExplorer(chainId!);
-  const [pageSize, setPageSize] = useState<number>(10);
+  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
 
    const columns: GridColDef<Dispute>[] = [
      {
@@ -91,9 +91,9 @@ export default function Arbitrable() {
            <DataGrid<Dispute>
              rows={disputes ? disputes! : []}
              columns={columns}
-             paginationModel={{ page: 0, pageSize }}
-             loading={isLoadingDisputes}
-             onPaginationModelChange={(model) => setPageSize(model.pageSize)}
+              paginationModel={paginationModel}
+              loading={isLoadingDisputes}
+              onPaginationModelChange={(model) => setPaginationModel(model)}
              pageSizeOptions={[10, 50, 100]}
              disableRowSelectionOnClick
              autoHeight={true}

--- a/src/pages/Arbitrables.tsx
+++ b/src/pages/Arbitrables.tsx
@@ -24,7 +24,7 @@ export default function Arbitrables() {
   const chainId = match ? match[1] : null
   const { data: arbitrables, isLoading } = useArbitrables(chainId!);
   const { data: arbitrablesNames } = useArbitrablesNames();
-  const [pageSize, setPageSize] = useState<number>(10);
+  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
   const columns: GridColDef<Arbitrable>[] = [
      {
        field: "id",
@@ -81,9 +81,9 @@ export default function Arbitrables() {
          <DataGrid<Arbitrable>
            rows={arbitrables ? arbitrables! : []}
            columns={columns}
-           paginationModel={{ page: 0, pageSize }}
-           loading={isLoading}
-           onPaginationModelChange={(model) => setPageSize(model.pageSize)}
+            paginationModel={paginationModel}
+            loading={isLoading}
+            onPaginationModelChange={(model) => setPaginationModel(model)}
            pageSizeOptions={[10, 50, 100]}
             disableRowSelectionOnClick
            autoHeight={true}

--- a/src/pages/Courts.tsx
+++ b/src/pages/Courts.tsx
@@ -17,7 +17,7 @@ export default function Courts() {
   const chainId = match ? match[1] : null;
   const { data, isLoading } = useCourts({ chainId: chainId! });
 
-  const [pageSize, setPageSize] = useState<number>(10);
+  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
 
   const columns: GridColDef<Court>[] = [
     { field: "id", headerName: "Court Id", flex: 1, type: "number" },
@@ -111,9 +111,9 @@ export default function Courts() {
          <DataGrid<Court>
            rows={data ? data! : []}
            columns={columns}
-           paginationModel={{ page: 0, pageSize }}
-           loading={isLoading}
-           onPaginationModelChange={(model) => setPageSize(model.pageSize)}
+            paginationModel={paginationModel}
+            loading={isLoading}
+            onPaginationModelChange={(model) => setPaginationModel(model)}
            pageSizeOptions={[10, 50, 100]}
            initialState={{
              sorting: { sortModel: [{ field: "id", sort: "asc" }] },

--- a/src/pages/Disputes.tsx
+++ b/src/pages/Disputes.tsx
@@ -15,7 +15,7 @@ export default function Disputes() {
   const match = location.pathname.match("(11155111|100|1)(?:/|$)");
   const chainId = match ? match[1] : null;
   const { data: disputes, isLoading } = useDisputes({ chainId: chainId! });
-  const [pageSize, setPageSize] = useState<number>(10);
+  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
 
   const columns: GridColDef<Dispute>[] = [
      {
@@ -77,9 +77,9 @@ export default function Disputes() {
          <DataGrid<Dispute>
            rows={disputes ? disputes! : []}
            columns={columns}
-           paginationModel={{ page: 0, pageSize }}
-           loading={isLoading}
-           onPaginationModelChange={(model) => setPageSize(model.pageSize)}
+            paginationModel={paginationModel}
+            loading={isLoading}
+            onPaginationModelChange={(model) => setPaginationModel(model)}
            pageSizeOptions={[10, 50, 100]}
             disableRowSelectionOnClick
            initialState={{

--- a/src/pages/Odds.tsx
+++ b/src/pages/Odds.tsx
@@ -49,7 +49,7 @@ export default function Odds() {
   const [odds, setOdds] = useState<JurorOdds[] | undefined>(undefined);
   const [pnkStaked, setPnkStaked] = useState<number>(100000);
   const [nJurors, setNJurors] = useState<number>(3);
-  const [pageSize, setPageSize] = useState<number>(10);
+  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
   const {data: pnkInfo} = useTokenInfo('kleros');
 
   const handleSetNJuror = (e: React.ChangeEvent<HTMLInputElement>)=> {
@@ -185,9 +185,9 @@ export default function Odds() {
       {<DataGrid<JurorOdds>
          rows={odds ? odds! : []}
          columns={columns}
-         paginationModel={{ page: 0, pageSize }}
-         loading={isLoading}
-         onPaginationModelChange={(model) => setPageSize(model.pageSize)}
+          paginationModel={paginationModel}
+          loading={isLoading}
+          onPaginationModelChange={(model) => setPaginationModel(model)}
          pageSizeOptions={[10, 50, 100]}
          disableRowSelectionOnClick
          autoHeight={true}

--- a/src/pages/Stakes.tsx
+++ b/src/pages/Stakes.tsx
@@ -20,7 +20,7 @@ export default function Stakes() {
   const chainId = match ? match[1] : null
 
   const { data: stakes, isLoading } = useStakes({chainId:chainId!});
-  const [pageSize, setPageSize] = useState<number>(10);
+  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
 
    const columns: GridColDef<StakeSet>[] = [
      {
@@ -68,9 +68,9 @@ export default function Stakes() {
        {<DataGrid<StakeSet>
          rows={stakes ? stakes! : []}
          columns={columns}
-         paginationModel={{ page: 0, pageSize }}
-         loading={isLoading}
-        onPaginationModelChange={(model) => setPageSize(model.pageSize)}
+          paginationModel={paginationModel}
+          loading={isLoading}
+         onPaginationModelChange={(model) => setPaginationModel(model)}
         pageSizeOptions={[10, 50, 100]}
          disableRowSelectionOnClick
          autoHeight={true}


### PR DESCRIPTION
## Summary

- DataGrid pagination was broken across all table views — clicking page 2 would reset to page 0 because `paginationModel` had `page` hardcoded and only `pageSize` was stored in state.

## Changes

| File | Change |
|------|--------|
| `src/pages/Arbitrables.tsx` | Store full paginationModel in state |
| `src/pages/Courts.tsx` | Same |
| `src/pages/Disputes.tsx` | Same |
| `src/pages/Arbitrable.tsx` | Same |
| `src/pages/Stakes.tsx` | Same |
| `src/pages/Odds.tsx` | Same |
| `src/components/Profile/CreatedCases.tsx` | Added missing state + onChange |
| `src/components/Profile/VotedCases.tsx` | Store full paginationModel in state |
| `src/components/LatestStakes.tsx` | Same |
| `src/components/LatestDisputes.tsx` | Same |

## Root cause

```tsx
// Before: page always resets to 0
const [pageSize, setPageSize] = useState(10);
paginationModel={{ page: 0, pageSize }}
onPaginationModelChange={(model) => setPageSize(model.pageSize)}

// After: page is preserved
const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 });
paginationModel={paginationModel}
onPaginationModelChange={(model) => setPaginationModel(model)}
```

## Test plan

- [x] `npx tsc --noEmit` passes with 0 errors
- [x] Navigate between pages in each table — should stay on the selected page